### PR TITLE
Bug fix for issue #71 -  CancelTradeWebCmd failing.

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -131,10 +131,18 @@ namespace SteamBot
                         try
                         {
                             CurrentTrade.Poll ();
+
+                            if (CurrentTrade.OtherUserCancelled)
+                            {
+                                log.Info("Other user cancelled the trade.");
+                                CurrentTrade = null;
+                            }
                         }
                         catch (Exception e)
                         {
                             log.Error ("Error Polling Trade: " + e);
+                            // ok then we should stop polling...
+                            CurrentTrade = null;
                         }
                     }
                 }

--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -49,8 +49,6 @@ namespace SteamTrade
         private dynamic othersItems;
         private dynamic myItems;
 
-        //private TradeSession tradeSession;
-
         public Trade (SteamID me, SteamID other, string sessionId, string token, string apiKey, int maxTradeTime, int maxGapTime)
         {
             mySteamId = me;
@@ -190,6 +188,11 @@ namespace SteamTrade
         {
             get { return tradeStarted; }
         }
+
+        /// <summary>
+        /// Gets a value indicating if the remote trading partner cancelled the trade.
+        /// </summary>
+        public bool OtherUserCancelled { get; private set; }
 
         #endregion
                 
@@ -463,9 +466,9 @@ namespace SteamTrade
             if (status.trade_status == 3)
             {
                 if (OnError != null)
-                    OnError ("Trade was cancelled");
+                    OnError ("Trade was cancelled by other user.");
 
-                CancelTrade ();
+                OtherUserCancelled = true;
                 return;
             }
 


### PR DESCRIPTION
When the remote user cancels the trade all bets are off for calling any of the web interaction functions.

Any method trying to call the web command functions should probably check the added `OtherUserCancelled` property before doing so. 

I noticed that there is an edge case that still fails where a remote user cancels before the the Trade class is fully ready. When the Simple Handler sends the message to put up items it throws another exception.
