### PR TITLE
Update C# Solution level formatting for MonoDevelop.

### DIFF
--- a/SteamBot.sln
+++ b/SteamBot.sln
@@ -230,8 +230,12 @@ Global
 		$2.scope = text/x-csharp
 		$0.CSharpFormattingPolicy = $3
 		$3.AnonymousMethodBraceStyle = NextLine
+		$3.PropertyBraceStyle = NextLine
 		$3.PropertyGetBraceStyle = NextLine
 		$3.PropertySetBraceStyle = NextLine
+		$3.EventBraceStyle = NextLine
+		$3.EventAddBraceStyle = NextLine
+		$3.EventRemoveBraceStyle = NextLine
 		$3.StatementBraceStyle = NextLine
 		$3.inheritsSet = Mono
 		$3.inheritsScope = text/x-csharp


### PR DESCRIPTION
This should make development with MD conform to project brace settings.

I'm not sure about how it will work with Visual Studio but after seeing Philipp's changes I figured this was possible and went ahead to make these format changes.

I think Visual Studio pretty much does the same format _except_ for the space before the opening parenthesis. But I don't think that's embedded into the `sln` file.
