### PR TITLE
Expose the Bot's Inventory in trade.

### DIFF
--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -131,7 +131,15 @@ namespace SteamTrade
         /// Gets the inventory of the other user. 
         /// </summary>
         public Inventory OtherInventory { get; private set; }
-        
+
+        /// <summary> 
+        /// Gets the inventory of the bot.
+        /// </summary>
+        public Inventory MyInventory
+        {
+            get { return myInventory; }
+        }
+
         /// <summary>
         /// Gets the items the user has offered, by itemid.
         /// </summary>


### PR DESCRIPTION
Fix for issue #90.

This will expose the bot's inventory to users of the Trade class. Use the new MyInventory property to get the bot's inventory.
