### PR TITLE
Update Solution Options to Conform to Project.

### DIFF
--- a/SteamBot.sln
+++ b/SteamBot.sln
@@ -237,6 +237,9 @@ Global
 		$3.EventAddBraceStyle = NextLine
 		$3.EventRemoveBraceStyle = NextLine
 		$3.StatementBraceStyle = NextLine
+		$3.ElseNewLinePlacement = NewLine
+		$3.CatchNewLinePlacement = NewLine
+		$3.FinallyNewLinePlacement = NewLine
 		$3.inheritsSet = Mono
 		$3.inheritsScope = text/x-csharp
 		$3.scope = text/x-csharp


### PR DESCRIPTION
Tried formatting a document w/ Monodevelop and saw that there were a few issues with certain places where MD didn't put brackets on their own line (`else`, `catch`, `finally`)

This is fairly small pull request as it's just Monodevelop settings in the `.sln` file.
