### PR TITLE
Save the Steam Guard Authentication.

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -54,15 +54,6 @@ namespace SteamBot
         // trade actions.
         public int MaximiumActionGap { get; private set; }
 
-        // The bot's username (for the steam account).
-        //string Username;
-
-        // The bot's password (for the steam account).
-        //string Password;
-
-        // The SteamGuard authcode, if needed.
-        //string AuthCode;
-
         // The Steam Web API key.
         string apiKey;
 
@@ -116,9 +107,6 @@ namespace SteamBot
             SteamTrade = SteamClient.GetHandler<SteamTrading>();
             SteamUser = SteamClient.GetHandler<SteamUser>();
             SteamFriends = SteamClient.GetHandler<SteamFriends>();
-
-
-
             log.Info ("Connecting...");
             SteamClient.Connect();
 
@@ -129,8 +117,6 @@ namespace SteamBot
                     CallbackMsg msg = SteamClient.WaitForCallback (true);
 
                     HandleSteamMessage (msg);
-
-                    //callbacks.RunWaitCallbacks(TimeSpan.FromMilliseconds(50));
                 }
             });
 
@@ -188,7 +174,8 @@ namespace SteamBot
         /// <summary>
         /// Closes the current active trade.
         /// </summary>
-        public void CloseTrade() {
+        public void CloseTrade() 
+        {
             if (CurrentTrade == null)
                 return;
             GetUserHandler (CurrentTrade.OtherSID).UnsubscribeTrade ();
@@ -369,7 +356,7 @@ namespace SteamBot
             #endregion
         }
 
-        private void UserLogOn()
+        void UserLogOn()
         {
             // get sentry file which has the machine hw info saved 
             // from when a steam guard code was entered
@@ -383,7 +370,7 @@ namespace SteamBot
             SteamUser.LogOn(logOnDetails);
         }
 
-        private UserHandler GetUserHandler (SteamID sid)
+        UserHandler GetUserHandler (SteamID sid)
         {
             if (!userHandlers.ContainsKey (sid))
             {
@@ -392,7 +379,7 @@ namespace SteamBot
             return userHandlers [sid.ConvertToUInt64 ()];
         }
 
-        private static byte [] SHAHash (byte[] input)
+        static byte [] SHAHash (byte[] input)
         {
             SHA1Managed sha = new SHA1Managed();
             


### PR DESCRIPTION
This was copied from the [SteamRE DepotDownloader](http://hg.opensteamworks.org/steamre/src/0486f95a9d3d/Projects/DepotDownloader/DepotDownloader/Steam3Session.cs).

It writes out a username.sentryfile that contains the Steam Guard machine ID stuff and, upon restart, uses that file info as part of the login as the machine ID.

Tested this w/ a Steam Guarded account and it appears to work (i.e. It doesn't prompt me to enter the Steam Guard code every time I debug the app).

 I'm unsure if there is any security risk to doing this but I think people using this should be smart enough to defend their sentries.... er... `sentryfiles`.

I think this should address Issue #93
