### PR TITLE
Update SteamBot/Bot.cs

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -394,7 +394,7 @@ namespace SteamBot
         {
             byte[] hash = SHAHash (machineAuth.Data);
 
-            File.WriteAllBytes (String.Format ("{0}.sentryFile", logOnDetails.Username), machineAuth.Data);
+            File.WriteAllBytes (String.Format ("{0}.sentryfile", logOnDetails.Username), machineAuth.Data);
             
             var authResponse = new SteamUser.MachineAuthDetails
             {


### PR DESCRIPTION
Fixes issue #100. In Linux file names are case sensitive. The bug described in issue #100 causes the bot running under Linux to miss existing sentryfile.
