### PR TITLE
Extra error checking before adding items to a trade

### DIFF
--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -226,7 +226,7 @@ namespace SteamTrade
             List<Inventory.Item> items = MyInventory.GetItemsByDefindex (defindex);
             foreach (Inventory.Item item in items)
             {
-                if (!myOfferedItems.ContainsValue (item.Id))
+                if (item != null && !myOfferedItems.ContainsValue(item.Id) && !item.IsNotTradeable)
                 {
                     return AddItem (item.Id);
                 }
@@ -249,7 +249,7 @@ namespace SteamTrade
 
             foreach (Inventory.Item item in items)
             {
-                if (item != null && !myOfferedItems.ContainsValue (item.Id))
+                if (item != null && !myOfferedItems.ContainsValue(item.Id) && !item.IsNotTradeable)
                 {
                     bool success = AddItem (item.Id);
 


### PR DESCRIPTION
Checks to ensure an item is trade-able before attempting to add an item to a trade.
