### PR TITLE
Wrong bot behaviour being used when multiple bots.

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -13,6 +13,7 @@ namespace SteamBot
 {
     public class Bot
     {
+        public string BotControlClass;
         // If the bot is logged in fully or not.  This is only set
         // when it is.
         public bool IsLoggedIn = false;
@@ -26,7 +27,6 @@ namespace SteamBot
 
         // A list of SteamIDs that this bot recognizes as admins.
         public ulong[] Admins;
-
         public SteamFriends SteamFriends;
         public SteamClient SteamClient;
         public SteamTrading SteamTrade;
@@ -80,7 +80,6 @@ namespace SteamBot
                 Username = config.Username,
                 Password = config.Password
             };
-
             DisplayName  = config.DisplayName;
             ChatResponse = config.ChatResponse;
             MaximumTradeTime = config.MaximumTradeTime;
@@ -100,6 +99,7 @@ namespace SteamBot
             }
             log          = new Log (config.LogFile, this.DisplayName, LogLevel);
             CreateHandler = handlerCreator;
+            BotControlClass = config.BotControlClass;
 
             // Hacking around https
             ServicePointManager.ServerCertificateValidationCallback += SteamWeb.ValidateRemoteCertificate;
@@ -111,7 +111,7 @@ namespace SteamBot
             SteamFriends = SteamClient.GetHandler<SteamFriends>();
             log.Info ("Connecting...");
             SteamClient.Connect();
-
+            
             Thread CallbackThread = new Thread(() => // Callback Handling
             {
                 while (true)
@@ -120,8 +120,8 @@ namespace SteamBot
 
                     HandleSteamMessage (msg);
                 }
-            });
-
+            }); 
+            
             CallbackThread.Start();
             log.Success ("Done Loading Bot!");
             CallbackThread.Join();

--- a/SteamBot/Program.cs
+++ b/SteamBot/Program.cs
@@ -23,10 +23,11 @@ namespace SteamBot
                         {
                             try
                             {
-                                new Bot(info, config.ApiKey, (Bot bot, SteamID sid) => 
-                                {
-                                    return (SteamBot.UserHandler)System.Activator.CreateInstance(Type.GetType(info.BotControlClass), new object[] { bot, sid });
-                                }, true);
+                                new Bot(info, config.ApiKey, (Bot bot, SteamID sid) => {
+                                    
+                                    return (SteamBot.UserHandler)System.Activator.CreateInstance(Type.GetType(bot.BotControlClass), new object[] { bot, sid });  
+                                }, false);
+
                             }
                             catch (Exception e)
                             {


### PR DESCRIPTION
I was having an issue earlier where all the bots in the config would use the behaviour of the last bot in the config, it seems it would set the correct bot class but not use it, the statement above is from testing that i performed, so I can not guarantee that is the case for everyone. The code below seems to have fixed this for me.

PS: Sorry that i made such an awful screw up on the previous pull request.
