### PR TITLE
Add Inventory Token to SteamTrade.

### DIFF
--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -104,6 +104,9 @@ namespace SteamTrade
 
             [JsonProperty("level")]
             public byte Level { get; set; }
+            
+            [JsonProperty("inventory")]
+            public uint InventoryToken { get; set; }
 
             [JsonProperty("quality")]
             public string Quality { get; set; }


### PR DESCRIPTION
Inventory token contains backpack placement info. It's useful. :P
