### PR TITLE
Replaces Current Trade Event Checking Fixes #219

### DIFF
--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -382,43 +382,6 @@ namespace SteamTrade
         }
 
         /// <summary>
-        /// Returns if the trade event list contains an event
-        /// I know this is messy, but the .Contains() didn't work for me at all.
-        /// </summary>
-        /// <param name="tradeEvent">Event to check</param>
-        /// <returns>True if found, False if not</returns>
-        public bool ContainsEvent(TradeEvent tradeEvent)
-        {
-            foreach (TradeEvent trdevent in eventList)
-            {
-                if (tradeEvent.action == trdevent.action)
-                {
-                    if (tradeEvent.appid == trdevent.appid)
-                    {
-                        if (tradeEvent.assetid == trdevent.assetid)
-                        {
-                            if (tradeEvent.contextid == trdevent.contextid)
-                            {
-                                if (tradeEvent.steamid == trdevent.steamid)
-                                {
-                                    if (tradeEvent.text == trdevent.text)
-                                    {
-                                        if (tradeEvent.timestamp == trdevent.timestamp)
-                                        {
-                                            return true;
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return false;
-        }
-
-
-        /// <summary>
         /// This updates the trade.  This is called at an interval of a
         /// default of 800ms, not including the execution time of the
         /// method itself.
@@ -457,7 +420,7 @@ namespace SteamTrade
             {
                 foreach (TradeEvent trdEvent in status.events)
                 {
-                    if (!ContainsEvent(trdEvent))
+                    if (!eventList.Contains(trdEvent))
                     {
                         eventList.Add(trdEvent);//add event to processed list, as we are taking care of this event now
                         bool isBot = trdEvent.steamid == MySteamId.ConvertToUInt64().ToString();

--- a/SteamTrade/TradeSession.cs
+++ b/SteamTrade/TradeSession.cs
@@ -226,7 +226,7 @@ namespace SteamTrade
             public TradeEvent[] events { get; set; }
         }
 
-        public class TradeEvent
+        public class TradeEvent : IEquatable<TradeEvent>
         {
             public string steamid { get; set; }
             
@@ -241,6 +241,26 @@ namespace SteamTrade
             public int contextid { get; set; }
             
             public ulong assetid { get; set; }
+
+            /// <summary>
+            /// Determins if the TradeEvent is equal to another.
+            /// </summary>
+            /// <param name="other">TradeEvent to compare to</param>
+            /// <returns>True if equal, false if not</returns>
+            public bool Equals(TradeEvent other)
+            {
+                if (this.steamid == other.steamid && this.action == other.action
+                    && this.timestamp == other.timestamp && this.appid == other.appid
+                    && this.text == other.text && this.contextid == other.contextid
+                    && this.assetid == other.assetid)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
         }
         
         public class TradeUserObj


### PR DESCRIPTION
This changes the current way of checking events processed. Instead of
having a number, and using a for loop, this adds the events that are
processed into a list. Every time a status is obtained, it checks every
event to make sure it hasn't missed anything. I did have to add a method
that checks if the list contains the event, as List.Contains() was not
working, and kept triggering the events multiple times.

Ever since I have put this in, the bots have not missed any removing of
items, and it has been well over a week, with a decent amount of trades.
