### PR TITLE
Separate Process auth Fix, AuthCode Change, Fixes #275

### DIFF
--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -172,6 +172,14 @@ namespace SteamBot
             {
                 if (!botProcs[index].UsingProcesses)
                     botProcs[index].TheBot.AuthCode = AuthCode;
+                else
+                {
+                    //  Write out auth code to the bot process' stdin
+                    StreamWriter BotStdIn = botProcs[index].BotProcess.StandardInput;
+
+                    BotStdIn.WriteLine(AuthCode);
+                    BotStdIn.Flush();
+                }
             }
         }
 
@@ -268,11 +276,14 @@ namespace SteamBot
                 botProc.StartInfo.Arguments = @"-bot " + botIndex;
 
                 // Set UseShellExecute to false for redirection.
-                botProc.StartInfo.UseShellExecute = true;
+                botProc.StartInfo.UseShellExecute = false;
 
                 // Redirect the standard output.  
                 // This stream is read asynchronously using an event handler.
                 botProc.StartInfo.RedirectStandardOutput = false;
+
+                // Redirect standard input to allow manager commands to be read properly
+                botProc.StartInfo.RedirectStandardInput = true;
 
                 // Set our event handler to asynchronously read the output.
                 //botProc.OutputDataReceived += new DataReceivedEventHandler(BotStdOutHandler);

--- a/SteamBot/Program.cs
+++ b/SteamBot/Program.cs
@@ -70,7 +70,7 @@ namespace SteamBot
 
             if (configObject.Bots.Length > botIndex)
             {
-                Bot b = new Bot(configObject.Bots[botIndex], configObject.ApiKey, BotManager.UserHandlerCreator, true);
+                Bot b = new Bot(configObject.Bots[botIndex], configObject.ApiKey, BotManager.UserHandlerCreator, true, true);
                 Console.Title = configObject.Bots[botIndex].DisplayName;
                 b.StartBot(); // never returns from this.
             }


### PR DESCRIPTION
This branch contains a fix for the auth command not setting the SteamGuard auth code for bots using separate processes. As a bonus it also includes a change to make Bot.AuthCode use default accessors, as per @Geel9's request.
