### PR TITLE
High CPU fix. Closes #290

### DIFF
--- a/SteamBot/Program.cs
+++ b/SteamBot/Program.cs
@@ -75,11 +75,11 @@ namespace SteamBot
                 b.StartBot(); // never returns from this.
             }
 
+            // this loop is needed to keep the botmode console alive.
+            // the sleep keeps the cpu usage low.
             while (true)
             {
-                // we need this in here so we can keep
-                // the console alive so we can read the 
-                // steamguard code if need be.
+                System.Threading.Thread.Sleep(1000);
             }
         }
 


### PR DESCRIPTION
> When bots are in separate process mode the bot had an empty loop to keep the console open and the process alive. This needed a sleep so it didn't peg CPU time.

Pretty easy. I tried removing it entirely and the separate process closed. I tried using `Console.ReadLine` and the auth command stop working.

Seemed like the best idea was to sleep this loop. It's not elegant.

See #290
