### PR TITLE
SimpleUserHandler failsafes

### DIFF
--- a/SteamBot/SimpleUserHandler.cs
+++ b/SteamBot/SimpleUserHandler.cs
@@ -56,6 +56,9 @@ namespace SteamBot
         
         public override void OnTradeReady (bool ready) 
         {
+            //Because SetReady must use its own version, it's important
+            //we poll the trade to make sure everything is up-to-date.
+            Trade.Poll();
             if (!ready)
             {
                 Trade.SetReady (false);
@@ -74,16 +77,16 @@ namespace SteamBot
         {
             if (Validate() || IsAdmin)
             {
-                bool success = Trade.AcceptTrade();
+                //Even if it is successful, AcceptTrade can fail on
+                //trades with a lot of items so we use a try-catch
+                try {
+                    Trade.AcceptTrade();
+                }
+                catch {
+                    Log.Warn ("The trade might have failed, but we can't be sure.");
+                }
 
-                if (success)
-                {
-                    Log.Success ("Trade was Successful!");
-                }
-                else
-                {
-                    Log.Warn ("Trade might have failed.");
-                }
+                Log.Success ("Trade Complete!");
             }
 
             OnTradeClose ();


### PR DESCRIPTION
Adds some failsafes: A try-catch for AcceptTrade() and a Poll on OnTradeReady()

It was discovered after testing that having a lot of items in the trade may cause AcceptTrade() to give an exception, making the bot crash even though the trade would go through.

The Trade.Poll is also added to OnTradeReady() to prevent another sort of crash that has been discussed recently.

It's best we add these in now rather than have more related issues from new users in the future.
