### PR TITLE
Fix for successful trade completion.

### DIFF
--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -112,6 +112,12 @@ namespace SteamTrade
         /// </summary>
         public bool OtherUserCancelled { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the trade completed normally. This
+        /// is independent of other flags.
+        /// </summary>
+        public bool HasTradeCompletedOk { get; private set; }
+
         #endregion
                 
         #region Public Events
@@ -439,6 +445,14 @@ namespace SteamTrade
                 return otherDidSomething;
             }
 
+            if (status.trade_status == 1)
+            {
+                // trade completed successfully.
+                HasTradeCompletedOk = true;
+                return otherDidSomething;
+            }
+
+
             if (status.events != null)
             {
                 foreach (TradeEvent trdEvent in status.events)
@@ -561,6 +575,14 @@ namespace SteamTrade
             }
 
             return otherDidSomething;
+        }
+
+        internal void FireOnCloseEvent()
+        {
+            var onCloseEvent = OnClose;
+
+            if (onCloseEvent != null)
+                onCloseEvent();
         }
 
         int NextTradeSlot ()

--- a/SteamTrade/TradeManager.cs
+++ b/SteamTrade/TradeManager.cs
@@ -274,20 +274,11 @@ namespace SteamTrade
                         if (action)
                             lastOtherActionTime = DateTime.Now;
                         
-                        if (trade.OtherUserCancelled)
+                        if (trade.OtherUserCancelled || trade.HasTradeCompletedOk)
                         {
                             IsTradeThreadRunning = false;
 
-                            try
-                            {
-                                trade.CancelTrade ();
-                            }
-                            catch (Exception)
-                            {
-                                // ignore. possibly log. We don't care if the Cancel web command fails here we just want 
-                                // to fire the OnClose event.
-                                DebugPrint ("[TRADEMANAGER] error trying to cancel from poll thread");
-                            }
+                            trade.FireOnCloseEvent();
                         }
 
                         CheckTradeTimeout (trade);
@@ -295,8 +286,8 @@ namespace SteamTrade
                     catch (Exception ex)
                     {
                         // TODO: find a new way to do this w/o the trade events
-//                        if (OnError != null)
-//                            OnError ("Error Polling Trade: " + e);
+                        //if (OnError != null)
+                        //    OnError("Error Polling Trade: " + e);
                         
                         // ok then we should stop polling...
                         IsTradeThreadRunning = false;


### PR DESCRIPTION
This should partially resolve some issues whereby trades weren't closed out properly and the timeout thread still ran. This caused some people to either restart their bots or wait for the timeout to occur. 

The code here's pretty easy. A new `trade_status` value needed to be checked in the `Poll` and exposed properly.

This doesn't necessarily fix issues with trades that went tits-up and failed. 

> Commit log:
> This checks the trade status for trades that end successfully. It then shuts down
> the trade normally. The Trade.OnClose event is fired correctly as well. This fixes
> long-standing bugs where a bot couldn't accept trades until it timed out (as if
> it was still in trade).
