### PR TITLE
Fixed Bot Start/Stop Error

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -75,6 +75,7 @@ namespace SteamBot
         string sessionId;
         string token;
         bool isprocess;
+        public bool IsRunning = false;
 
         public string AuthCode { get; set; }
 
@@ -149,6 +150,8 @@ namespace SteamBot
         /// <returns><c>true</c>. See remarks</returns>
         public bool StartBot()
         {
+            IsRunning = true;
+
             log.Info("Connecting...");
 
             if (!backgroundWorker.IsBusy)
@@ -168,7 +171,9 @@ namespace SteamBot
         /// </summary>
         public void StopBot()
         {
-            log.Debug("Tryring to shut down bot thread.");
+            IsRunning = false;
+
+            log.Debug("Trying to shut down bot thread.");
             SteamClient.Disconnect();
 
             backgroundWorker.CancelAsync();

--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -57,7 +57,7 @@ namespace SteamBot
             for (int i = 0; i < ConfigObject.Bots.Length; i++)
             {
                 Configuration.BotInfo info = ConfigObject.Bots[i];
-                if (info.AutoStart)
+                if (ConfigObject.AutoStartAllBots || info.AutoStart)
                 {
                     mainLog.Info("Launching Bot " + info.DisplayName + "...");
                 }
@@ -247,41 +247,40 @@ namespace SteamBot
 
             public void Stop()
             {
-                if (IsRunning)
+                if (IsRunning && UsingProcesses)
                 {
-                    if (UsingProcesses)
+                    if (!BotProcess.HasExited)
                     {
-                        if (!BotProcess.HasExited)
-                        {
-                            BotProcess.Kill();
-                            IsRunning = false;
-                        }
+                        BotProcess.Kill();
+                        IsRunning = false;
                     }
-                    else
-                    {
-                        if (TheBot != null)
-                        {
-                            TheBot.StopBot();
-                            IsRunning = false;
-                        }
-                    }
+                }
+                else if (TheBot != null && TheBot.IsRunning)
+                {
+                    TheBot.StopBot();
+                    IsRunning = false;
                 }
             }
 
             public void Start()
             {
-                if (!IsRunning)
+                if (UsingProcesses)
                 {
-                    if (UsingProcesses)
+                    if (!IsRunning)
                     {
                         SpawnSteamBotProcess(BotConfigIndex);
                         IsRunning = true;
                     }
-                    else
-                    {
-                        SpawnBotThread(BotConfig);
-                        IsRunning = true;
-                    }
+                }
+                else if (TheBot == null)
+                {
+                    SpawnBotThread(BotConfig);
+                    IsRunning = true;
+                }
+                else if (!TheBot.IsRunning)
+                {
+                    SpawnBotThread(BotConfig);
+                    IsRunning = true;
                 }
             }
 


### PR DESCRIPTION
Fixes a `StartBot()`/`StopBot()` error. Calls to `StopBot()` from within the bot caused the BotManager to have an incorrect status of the RunningBot when not using separate processes. Added `IsRunning` Bot.cs to account for this. Also fixed mainLog not displaying launch info if a bot was set to not autostart while using `AutoStartAllBots`. Corrected minor typo in `Bot.StopBot` as well.

This should fix #329

Edit: Originally left out the exclamation point in one of the conditionals. Recommitted for a clean history.
