### PR TITLE
Correct captchagid key name for request body.

### DIFF
--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -121,7 +121,7 @@ namespace SteamTrade
                     capText = Uri.EscapeDataString (Console.ReadLine ());
                 }
 
-                data.Add ("captcha_gid", captcha ? capGID : "");
+                data.Add ("captchagid", captcha ? capGID : "");
                 data.Add ("captcha_text", captcha ? capText : "");
                 // Captcha end
 


### PR DESCRIPTION
Noticed a problem there the captcha gid was being incorrectly sent to the steam web server as captcha_gid. The correct key is captchagid.

Attached image of the current steamcommunity.com javascript used for this same auth procedure.
![screen shot 2013-10-03 at 11 34 20 pm](https://f.cloud.github.com/assets/1611098/1267475/0dd090d4-2cbf-11e3-820a-78ca4f332be8.png)
