### PR TITLE
GenericInventory and SteamTradeDemoHandler FIXES

### DIFF
--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -12,14 +12,17 @@ namespace SteamBot
         private bool tested;
         // ----------------------------------------------------------------------
 
-        public SteamTradeDemoHandler (Bot bot, SteamID sid) : base(bot, sid) {}
+        public SteamTradeDemoHandler(Bot bot, SteamID sid) : base(bot, sid) { }
 
-        public override bool OnFriendAdd () 
+        public override bool OnFriendAdd()
         {
             return true;
         }
 
-        public override void OnLoginCompleted() {}
+        public override void OnLoginCompleted()
+        {
+            Bot.SteamFriends.SetPersonaState(EPersonaState.LookingToTrade);
+        }
 
         public override void OnChatRoomMessage(SteamID chatID, SteamID sender, string message)
         {
@@ -27,37 +30,39 @@ namespace SteamBot
             base.OnChatRoomMessage(chatID, sender, message);
         }
 
-        public override void OnFriendRemove () {}
-        
-        public override void OnMessage (string message, EChatEntryType type) 
+        public override void OnFriendRemove() { }
+
+        public override void OnMessage(string message, EChatEntryType type)
         {
             Bot.SteamFriends.SendChatMessage(OtherSID, type, Bot.ChatResponse);
         }
 
-        public override bool OnTradeRequest() 
+        public override bool OnTradeRequest()
         {
             return true;
         }
-        
-        public override void OnTradeError (string error) 
+
+        public override void OnTradeError(string error)
         {
-            Bot.SteamFriends.SendChatMessage (OtherSID, 
+            Bot.SteamFriends.SendChatMessage(OtherSID,
                                               EChatEntryType.ChatMsg,
                                               "Oh, there was an error: " + error + "."
                                               );
-            Bot.log.Warn (error);
+            Bot.log.Warn(error);
+            Bot.SteamFriends.SetPersonaState(EPersonaState.LookingToTrade);
+        }
 
-        }
-        
-        public override void OnTradeTimeout () 
+        public override void OnTradeTimeout()
         {
-            Bot.SteamFriends.SendChatMessage (OtherSID, EChatEntryType.ChatMsg,
+            Bot.SteamFriends.SendChatMessage(OtherSID, EChatEntryType.ChatMsg,
                                               "Sorry, but you were AFK and the trade was canceled.");
-            Bot.log.Info ("User was kicked because he was AFK.");
+            Bot.log.Info("User was kicked because he was AFK.");
+            Bot.SteamFriends.SetPersonaState(EPersonaState.LookingToTrade);
         }
-        
-        public override void OnTradeInit() 
+
+        public override void OnTradeInit()
         {
+            Bot.SteamFriends.SetPersonaState(EPersonaState.Busy);
             // NEW -------------------------------------------------------------------------------
             List<int> contextId = new List<int>();
             tested = false;
@@ -68,11 +73,13 @@ namespace SteamBot
              * 
              *  Context Id      Description
              *      1           Gifts (Games), must be public on steam profile in order to work.
+             *      3           Coupons
              *      6           Trading Cards, Emoticons & Backgrounds. 
              *  
              ************************************************************************************/
 
             contextId.Add(1);
+            contextId.Add(3);
             contextId.Add(6);
 
             mySteamInventory.load(753, contextId, Bot.SteamClient.SteamID);
@@ -82,12 +89,12 @@ namespace SteamBot
             {
                 Trade.SendMessage("Couldn't open an inventory, type 'errors' for more info.");
             }
-
             Trade.SendMessage("Type 'test' to start.");
             // -----------------------------------------------------------------------------------
         }
-        
-        public override void OnTradeAddItem (Schema.Item schemaItem, Inventory.Item inventoryItem) {
+
+        public override void OnTradeAddItem(Schema.Item schemaItem, Inventory.Item inventoryItem)
+        {
             // USELESS DEBUG MESSAGES -------------------------------------------------------------------------------
             Trade.SendMessage("Object AppID: " + inventoryItem.AppId);
             Trade.SendMessage("Object ContextId: " + inventoryItem.ContextId);
@@ -99,14 +106,21 @@ namespace SteamBot
                     Trade.SendMessage("Name: " + schemaItem.Name);
                     Trade.SendMessage("Quality: " + inventoryItem.Quality);
                     Trade.SendMessage("Level: " + inventoryItem.Level);
-                    Trade.SendMessage("Craftable: " + (inventoryItem.IsNotCraftable?"No":"Yes"));
+                    Trade.SendMessage("Craftable: " + (inventoryItem.IsNotCraftable ? "No" : "Yes"));
+
+                    if (true)
+                    {
+                        Bot.log.Warn(OtherSID + " added: " + schemaItem.Name + "with quality: " + inventoryItem.Quality + " with level: " + inventoryItem.Level + ", type: TF2 Item, item craftable: " + (inventoryItem.IsNotCraftable ? "No" : "Yes"));
+                    }
+
                     break;
 
                 case 753:
                     GenericInventory.ItemDescription tmpDescription = OtherSteamInventory.getDescription(inventoryItem.Id);
                     Trade.SendMessage("Steam Inventory Item Added.");
                     Trade.SendMessage("Type: " + tmpDescription.type);
-                    Trade.SendMessage("Marketable: " + (tmpDescription.marketable?"Yes":"No"));
+                    Trade.SendMessage("Marketable: " + (tmpDescription.marketable ? "Yes" : "No"));
+                    Bot.log.Error(OtherSID + " added: " + tmpDescription.name + ", type: " + tmpDescription.type + ", item marketable: " + (tmpDescription.marketable ? "Yes" : "No"));
                     break;
 
                 default:
@@ -115,10 +129,38 @@ namespace SteamBot
             }
             // ------------------------------------------------------------------------------------------------------
         }
-        
-        public override void OnTradeRemoveItem (Schema.Item schemaItem, Inventory.Item inventoryItem) {}
-        
-        public override void OnTradeMessage (string message) {
+
+        public override void OnTradeRemoveItem(Schema.Item schemaItem, Inventory.Item inventoryItem)
+        {
+            // USELESS DEBUG MESSAGES -------------------------------------------------------------------------------
+            //Trade.SendMessage("Object AppID: " + inventoryItem.AppId);
+            //Trade.SendMessage("Object ContextId: " + inventoryItem.ContextId);
+
+            switch (inventoryItem.AppId)
+            {
+                case 440:
+                    if (true)
+                    {
+                        Bot.log.Warn(OtherSID + " removed: " + schemaItem.Name + "with quality: " + inventoryItem.Quality + " with level: " + inventoryItem.Level + ", type: TF2 Item, item craftable: " + (inventoryItem.IsNotCraftable ? "No" : "Yes"));
+                    }
+                    break;
+
+                case 753:
+                    GenericInventory.ItemDescription tmpDescription = OtherSteamInventory.getDescription(inventoryItem.Id);
+                    Bot.log.Error(OtherSID + " removed: " + tmpDescription.name + ", type: " + tmpDescription.type + ", item marketable: " + (tmpDescription.marketable ? "Yes" : "No"));
+                    break;
+
+                default:
+                    Trade.SendMessage("Unknown item");
+                    break;
+            }
+            // ------------------------------------------------------------------------------------------------------
+
+        }
+
+        public override void OnTradeMessage(string message)
+        {
+
             switch (message.ToLower())
             {
                 case "errors":
@@ -128,6 +170,7 @@ namespace SteamBot
                         foreach (string error in OtherSteamInventory.errors)
                         {
                             Trade.SendMessage(" * " + error);
+                            Bot.log.Error(" * " + error);
                         }
                     }
 
@@ -137,9 +180,10 @@ namespace SteamBot
                         foreach (string error in mySteamInventory.errors)
                         {
                             Trade.SendMessage(" * " + error);
+                            Bot.log.Error(" * " + error);
                         }
                     }
-                break;
+                    break;
 
                 case "test":
                     if (tested)
@@ -159,58 +203,82 @@ namespace SteamBot
                     }
 
                     tested = !tested;
-
-                break;
+                    break;
 
                 case "remove":
                     foreach (var item in mySteamInventory.items)
                     {
                         Trade.RemoveItem(item.Value.assetid, item.Value.appid, item.Value.contextid);
                     }
-                break;
+                    break;
             }
         }
-        
-        public override void OnTradeReady (bool ready) 
+
+        public override void OnTradeReady(bool ready)
         {
             //Because SetReady must use its own version, it's important
             //we poll the trade to make sure everything is up-to-date.
             Trade.Poll();
             if (!ready)
             {
-                Trade.SetReady (false);
+                Trade.SetReady(false);
             }
             else
             {
-                if(Validate () | IsAdmin)
+                if (Validate() | IsAdmin)
                 {
-                    Trade.SetReady (true);
+                    Trade.SetReady(true);
                 }
             }
         }
-        
-        public override void OnTradeAccept() 
+
+        public override void OnTradeAccept()
         {
-            if (Validate() | IsAdmin)
+            if (Validate() || IsAdmin)
             {
                 //Even if it is successful, AcceptTrade can fail on
                 //trades with a lot of items so we use a try-catch
-                try {
+                try
+                {
                     Trade.AcceptTrade();
                 }
-                catch {
-                    Log.Warn ("The trade might have failed, but we can't be sure.");
+                catch
+                {
+                    Log.Warn("The trade might have failed, but we can't be sure.");
                 }
 
-                Log.Success ("Trade Complete!");
-            }
+                Log.Success("Trade Complete!");
+                Bot.SteamFriends.SetPersonaState(EPersonaState.LookingToTrade);
 
-            OnTradeClose ();
+                // Since people seems getting a error like : There is already added an item with the same key, i found a way to fix this just to clear the descriptions and items dictionary.
+                OtherSteamInventory.descriptions.Clear();
+                OtherSteamInventory.items.Clear();
+                Bot.log.Success("description/items other cleared Complete!");
+                mySteamInventory.descriptions.Clear();
+                mySteamInventory.items.Clear();
+                Bot.log.Success("description/items me cleared Complete!");
+            }
+            OnTradeClose();
         }
 
-        public bool Validate ()
-        {            
-            List<string> errors = new List<string> ();
+        public override void OnTradeClose()
+        {
+            Bot.log.Warn("[USERHANDLER] TRADE CLOSED");
+            Bot.CloseTrade();
+            Bot.SteamFriends.SetPersonaState(EPersonaState.LookingToTrade);
+
+            // Since people seems getting a error like : There is already added an item with the same key, i found a way to fix this just to clear the descriptions and items dictionary.
+            OtherSteamInventory.descriptions.Clear();
+            OtherSteamInventory.items.Clear();
+            Bot.log.Warn("description/items other cleared Complete!");
+            mySteamInventory.descriptions.Clear();
+            mySteamInventory.items.Clear();
+            Bot.log.Warn("description/items me cleared Complete!");
+        }
+
+        public bool Validate()
+        {
+            List<string> errors = new List<string>();
             errors.Add("This demo is meant to show you how to handle SteamInventory Items. Trade cannot be completed, unless you're and Admin.");
 
             // send the errors
@@ -221,11 +289,8 @@ namespace SteamBot
             {
                 Trade.SendMessage(error);
             }
-            
             return errors.Count == 0;
         }
-        
     }
- 
 }
 

--- a/SteamTrade/GenericInventory.cs
+++ b/SteamTrade/GenericInventory.cs
@@ -122,8 +122,7 @@ namespace SteamTrade
                                 tmpAppData= null;
                             }
 
-                                
-                            descriptions.Add("" + (class_instance.classid??'0') + "_" + (class_instance.instaceid??'0'), 
+                            descriptions.Add("" + (class_instance.classid??'0') + "_" + (class_instance.instanceid??'0'), 
                                 new ItemDescription()
                                     {
                                         name = class_instance.name,


### PR DESCRIPTION
@GenericInventory
The change is a mispelling of the word "instanceid", since this was mispelled all instanceids were nulled.
Somehow this fixed it.

@SteamTradeDemoHandler
Note: most changes are made by Visual Studio 2012 itself so only check the changed below this text:

public override void OnTradeInit()
- added coupon support.

public override void OnTradeAddItem(Schema.Item schemaItem,Inventory.Item inventoryItem)
- added bot log warn / error message when a tf2 item or steam item is added. Just for debugging.

public override void OnTradeAccept()
- after trade is completed i fixed the error that people will get : There is already added an item with the same key
- i did this with the usage of the clear method to clear both dictionaries (descriptions and items)

public override void OnTradeClose()
- i added this method in the steamtradedemohandler so that when the user cancels the trade it also clears the dictionaries as method above for same reason.

If things aren't clear please let me know.

P.S. i've talked about the issues before with gabrielmtzcarrillo
