### PR TITLE
Schema.cs fix

### DIFF
--- a/SteamTrade/Schema.cs
+++ b/SteamTrade/Schema.cs
@@ -49,7 +49,7 @@ namespace SteamTrade
 
             HttpWebResponse response = SteamWeb.Request(url, "GET");
 
-            DateTime schemaLastModified = DateTime.Parse(response.Headers["Last-Modified"].Replace(" UTC", "Z"));
+            DateTime schemaLastModified = response.LastModified;
 
             string result = GetSchemaString(response, schemaLastModified);
 


### PR DESCRIPTION
Changes UTC to Z so it doesn't throw FormatException, and parses date/time as UTC

Fixes #500
