### PR TITLE
Load inventories asynchronously

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using System.Web;
 using System.Net;
 using System.Text;
@@ -83,9 +84,16 @@ namespace SteamBot
         SteamUser.LogOnDetails logOnDetails;
 
         TradeManager tradeManager;
+        private Task<Inventory> myInventoryTask;
 
-        public Inventory MyInventory;
-        public Inventory OtherInventory;
+        public Inventory MyInventory
+        {
+            get
+            {
+                myInventoryTask.Wait();
+                return myInventoryTask.Result;
+            }
+        }
 
         private BackgroundWorker backgroundWorker;
 
@@ -611,7 +619,7 @@ namespace SteamBot
         /// </example>
         public void GetInventory()
         {
-            MyInventory = Inventory.FetchInventory(SteamUser.SteamID, apiKey);
+            myInventoryTask = Task.Run(() => Inventory.FetchInventory(SteamUser.SteamID, apiKey));
         }
 
         /// <summary>
@@ -632,7 +640,7 @@ namespace SteamBot
         /// </example>
         public void GetOtherInventory(SteamID OtherSID)
         {
-            OtherInventory = Inventory.FetchInventory(OtherSID, apiKey);
+            Task.Run(() => Inventory.FetchInventory(OtherSID, apiKey));
         }
 
         /// <summary>

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>SteamBot</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>True</DebugSymbols>
@@ -22,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <Externalconsole>True</Externalconsole>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugType>none</DebugType>
@@ -31,6 +34,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <Externalconsole>True</Externalconsole>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -83,14 +87,14 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
-    <ProjectReference Include="..\SteamTrade\SteamTrade.csproj">
-      <Project>{6CEC0333-81EB-40EE-85D1-941363626FC7}</Project>
-      <Name>SteamTrade</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="app.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SteamTrade\SteamTrade.csproj">
+      <Project>{6cec0333-81eb-40ee-85d1-941363626fc7}</Project>
+      <Name>SteamTrade</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/SteamBot/app.config
+++ b/SteamBot/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.668" newVersion="2.0.0.668" />
+        <assemblyIdentity name="protobuf-net" publicKeyToken="257b51d87d2e4d67" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.668" newVersion="2.0.0.668"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/SteamBot/packages.config
+++ b/SteamBot/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" requireReinstallation="True" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net40" />
   <package id="SteamKit2" version="1.5.0" targetFramework="net40" />
 </packages>

--- a/SteamTrade/GenericInventory.cs
+++ b/SteamTrade/GenericInventory.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SteamKit2;
 using SteamTrade.TradeWebAPI;
@@ -12,11 +14,45 @@ namespace SteamTrade
     /// </summary>
     public class GenericInventory
     {
-        public Dictionary<ulong, Item> items = new Dictionary<ulong, Item>();
-        public Dictionary<string, ItemDescription> descriptions = new Dictionary<string, ItemDescription>();
+        public Dictionary<ulong, Item> items
+        {
+            get
+            {
+                if(_loadTask == null)
+                    return null;
+                _loadTask.Wait();
+                return _items;
+            }
+        }
+
+        public Dictionary<string, ItemDescription> descriptions
+        {
+            get
+            {
+                if(_loadTask == null)
+                    return null;
+                _loadTask.Wait();
+                return _descriptions;
+            }
+        }
+
+        public List<string> errors
+        {
+            get
+            {
+                if(_loadTask == null)
+                    return null;
+                _loadTask.Wait();
+                return _errors;
+            }
+        }
 
         public bool isLoaded = false;
-        public List<string> errors = new List<string>();
+
+        private Task _loadTask;
+        private Dictionary<string, ItemDescription> _descriptions = new Dictionary<string, ItemDescription>();
+        private Dictionary<ulong, Item> _items = new Dictionary<ulong, Item>();
+        private List<string> _errors = new List<string>();
 
         public class Item : TradeUserAssets
         {
@@ -57,9 +93,13 @@ namespace SteamTrade
 
         public ItemDescription getDescription(ulong id)
         {
+            if(_loadTask == null)
+                return null;
+            _loadTask.Wait();
+
             try
             {
-                return descriptions[items[id].descriptionid];
+                return _descriptions[_items[id].descriptionid];
             }
             catch (Exception e)
             {
@@ -68,15 +108,21 @@ namespace SteamTrade
             }
         }
 
-        public bool load(int appid, IEnumerable<long> contextIds, SteamID steamid)
+        public void load(int appid, IEnumerable<long> contextIds, SteamID steamid)
+        {
+            List<long> contextIdsCopy = contextIds.ToList();
+            _loadTask = Task.Run(() => loadImplementation(appid, contextIdsCopy, steamid));
+        }
+
+        public void loadImplementation(int appid, IEnumerable<long> contextIds, SteamID steamid)
         {
             dynamic invResponse;
             isLoaded = false;
             Dictionary<string, string> tmpAppData;
 
-            items.Clear();
-            descriptions.Clear();
-            errors.Clear();
+            _items.Clear();
+            _descriptions.Clear();
+            _errors.Clear();
 
             try
             {
@@ -87,7 +133,7 @@ namespace SteamTrade
 
                     if (invResponse.success == false)
                     {
-                        errors.Add("Fail to open backpack: " + invResponse.Error);
+                        _errors.Add("Fail to open backpack: " + invResponse.Error);
                         continue;
                     }
 
@@ -97,7 +143,7 @@ namespace SteamTrade
 
                         foreach (var itemId in item)
                         {
-                            items.Add((ulong)itemId.id, new Item()
+                            _items.Add((ulong)itemId.id, new Item()
                             {
                                 appid = appid,
                                 contextid = contextId,
@@ -126,8 +172,7 @@ namespace SteamTrade
                                 tmpAppData= null;
                             }
 
-                                
-                            descriptions.Add("" + (class_instance.classid??'0') + "_" + (class_instance.instaceid??'0'), 
+                            _descriptions.Add("" + (class_instance.classid??'0') + "_" + (class_instance.instanceid??'0'), 
                                 new ItemDescription()
                                     {
                                         name = class_instance.name,
@@ -140,20 +185,15 @@ namespace SteamTrade
                             break;
                         }
                     }
-
-                    if (errors.Count > 0)
-                        return false;
                     
                 }//end for (contextId)
             }//end try
             catch (Exception e)
             {
                 Console.WriteLine(e.Message);
-                errors.Add("Exception: " + e.Message);
-                return false;
+                _errors.Add("Exception: " + e.Message);
             }
             isLoaded = true;
-            return true;
         }
     }
 }

--- a/SteamTrade/SteamTrade.csproj
+++ b/SteamTrade/SteamTrade.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>SteamTrade</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -21,6 +23,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -29,6 +32,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
+    <DebugSymbols>true</DebugSymbols>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">

--- a/SteamTrade/packages.config
+++ b/SteamTrade/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net40" requireReinstallation="True" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net40" />
   <package id="SteamKit2" version="1.5.0" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
A common issue when the Steam servers are overloaded is that the bot continuously times out at the beginning of a trade.  The reason is that the Bot is required to call `Trade.Poll()` every few seconds to prevent a timeout, but loading the inventory with `Bot.GetInventory()` is blocking - if the inventory takes too long to load, the Bot won't call `Poll()` in time.

This pull request makes the inventory-loading asynchronous, and doesn't block until the bot attempts to use the inventory.  It affects both `Inventory` and `GenericInventory`, and shouldn't require any changes for existing `UserHander`s.

_(@geel9 pointed out it would be better to simply not call any `UserHandler` callbacks until the inventory is loaded.  While this is true, there's no way to do that while retaining backwards compatibility - existing bots would need major code changes)_

**This pull request requires an update to .Net 4.5**.  Since [Mono supports 4.5](http://www.mono-project.com/Compatibility), I don't _think_ that should cause any issues for anyone..
