### PR TITLE
Adds User Handler feedback on bot's trade request accept/decline.

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -503,11 +503,13 @@ namespace SteamBot
                 {
                     log.Debug ("Trade Status: " + callback.Response);
                     log.Info ("Trade Accepted!");
+                    GetUserHandler(callback.OtherClient).OnTradeRequestReply(true, callback.Response.ToString());
                 }
                 else
                 {
                     log.Warn ("Trade failed: " + callback.Response);
                     CloseTrade ();
+                    GetUserHandler(callback.OtherClient).OnTradeRequestReply(false, callback.Response.ToString());
                 }
 
             });

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -104,6 +104,16 @@ namespace SteamBot
 
         }
 
+        /// <summary>
+        /// Called when user accepts or denies bot's trade request.
+        /// </summary>
+        /// <param name="accepted">True if user accepted bot's request, false if not.</param>
+        /// <param name="response">String response of the callback.</param>
+        public virtual void OnTradeRequestReply(bool accepted, string response)
+        {
+
+        }
+
         #region Trade events
         // see the various events in SteamTrade.Trade for descriptions of these handlers.
 


### PR DESCRIPTION
A few users have asked for this before, and since I needed it myself, here you go.

Adds a new user handler event `OnTradeRequestReply()`. It's not critical to add it, your code will compile just fine without it.

The event will return `true` if the trade request sent by the bot has been accepted, `false` otherwise.
It will also provide you with a `string` of the callback response message.
