### PR TITLE
Added code for UserHandler disposal.

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -441,24 +441,25 @@ namespace SteamBot
                     }
                     else if (friend.SteamID.AccountType != EAccountType.Clan)
                     {
-                    if (!friends.Contains(friend.SteamID))
-                    {
-                        friends.Add(friend.SteamID);
-                        if (friend.Relationship == EFriendRelationship.RequestRecipient &&
-                            GetUserHandler(friend.SteamID).OnFriendAdd())
+                        if (!friends.Contains(friend.SteamID))
                         {
-                            SteamFriends.AddFriend(friend.SteamID);
+                            friends.Add(friend.SteamID);
+                            if (friend.Relationship == EFriendRelationship.RequestRecipient &&
+                                GetUserHandler(friend.SteamID).OnFriendAdd())
+                            {
+                                SteamFriends.AddFriend(friend.SteamID);
+                            }
+                        }
+                        else
+                        {
+                            if (friend.Relationship == EFriendRelationship.None)
+                            {
+                                friends.Remove(friend.SteamID);
+                                GetUserHandler(friend.SteamID).OnFriendRemove();
+                                RemoveUserHandler(friend.SteamID);
+                            }
                         }
                     }
-                    else
-                    {
-                        if (friend.Relationship == EFriendRelationship.None)
-                        {
-                            friends.Remove(friend.SteamID);
-                            GetUserHandler(friend.SteamID).OnFriendRemove();
-                        }
-                    }
-                }
                 }
             });
 
@@ -587,13 +588,21 @@ namespace SteamBot
             SteamUser.LogOn(logOnDetails);
         }
 
-        UserHandler GetUserHandler (SteamID sid)
+        UserHandler GetUserHandler(SteamID sid)
         {
-            if (!userHandlers.ContainsKey (sid))
+            if (!userHandlers.ContainsKey(sid))
             {
-                userHandlers [sid.ConvertToUInt64 ()] = CreateHandler (this, sid);
+                userHandlers[sid.ConvertToUInt64()] = CreateHandler(this, sid);
             }
-            return userHandlers [sid.ConvertToUInt64 ()];
+            return userHandlers[sid.ConvertToUInt64()];
+        }
+
+        void RemoveUserHandler(SteamID sid)
+        {
+            if (userHandlers.ContainsKey(sid))
+            {
+                userHandlers.Remove(sid);
+            }
         }
 
         static byte [] SHAHash (byte[] input)


### PR DESCRIPTION
Currently, the bot doesn't remove unused `UserHandler`s. Each `UserHandler` holds user's backpack (can be couple hundred kilobytes).
I have added short method to remove `UserHandler` if it exists. This method is activated when user removes the bot. This means that in worst case scenario, the bot will hold the amount of `UserHandler`s equal to his friends list size.

Diff: https://github.com/scholtzm/SteamBot/commit/fc7b44d84a33fc5b9265f1b042d3eaa6bb5d56ab?w=1
