### PR TITLE
Provide LogLevel option for the bot's logfile.

### DIFF
--- a/Bin/Debug/settings-template.json
+++ b/Bin/Debug/settings-template.json
@@ -17,6 +17,7 @@
             "DisplayNamePrefix":"[AutomatedBot] ",
             "TradePollingInterval":800,
             "LogLevel":"Success",
+            "FileLogLevel":"Info",
             "AutoStart": "true"
         }
     ]

--- a/Bin/Release/settings-template.json
+++ b/Bin/Release/settings-template.json
@@ -17,6 +17,7 @@
             "DisplayNamePrefix":"[AutomatedBot] ",
             "TradePollingInterval":800,
             "LogLevel":"Success",
+            "FileLogLevel":"Info",
             "AutoStart": "true"
         }
     ]

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -73,6 +73,7 @@ namespace SteamBot
 
         // Log level to use for this bot
         Log.LogLevel LogLevel;
+        Log.LogLevel FileLogLevel;
 
         // The number, in milliseconds, between polls for the trade.
         int TradePollingInterval;
@@ -117,16 +118,28 @@ namespace SteamBot
             Admins       = config.Admins;
             this.apiKey  = apiKey;
             this.isprocess = process;
+
             try
             {
                 LogLevel = (Log.LogLevel)Enum.Parse(typeof(Log.LogLevel), config.LogLevel, true);
             }
             catch (ArgumentException)
             {
-                Console.WriteLine("Invalid LogLevel provided in configuration. Defaulting to 'INFO'");
+                Console.WriteLine("Invalid Console LogLevel provided in configuration. Defaulting to 'INFO'");
                 LogLevel = Log.LogLevel.Info;
             }
-            log          = new Log (config.LogFile, this.DisplayName, LogLevel);
+
+            try
+            {
+                FileLogLevel = (Log.LogLevel)Enum.Parse(typeof(Log.LogLevel), config.FileLogLevel, true);
+            }
+            catch (ArgumentException)
+            {
+                Console.WriteLine("Invalid File LogLevel provided in configuration. Defaulting to 'INFO'");
+                FileLogLevel = Log.LogLevel.Info;
+            }
+
+            log          = new Log (config.LogFile, this.DisplayName, LogLevel, FileLogLevel);
             CreateHandler = handlerCreator;
             BotControlClass = config.BotControlClass;
 

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -128,6 +128,7 @@ namespace SteamBot
             public string DisplayNamePrefix { get; set; }
             public int TradePollingInterval { get; set; }
             public string LogLevel { get; set; }
+            public string FileLogLevel { get; set; }
             public ulong[] Admins { get; set; }
 
             /// <summary>

--- a/SteamBot/Log.cs
+++ b/SteamBot/Log.cs
@@ -24,15 +24,18 @@ namespace SteamBot
         protected StreamWriter _FileStream;
         protected string _Bot;
         public LogLevel OutputToConsole;
+        public LogLevel OutputToLogfile;
         public ConsoleColor DefaultConsoleColor = ConsoleColor.White;
 
-        public Log (string logFile, string botName = "", LogLevel output = LogLevel.Info)
+        public Log (string logFile, string botName = "", LogLevel outputConsole = LogLevel.Info, LogLevel outputFile = LogLevel.Info)
         {
             Directory.CreateDirectory(System.IO.Path.Combine(System.Windows.Forms.Application.StartupPath, "logs"));
             _FileStream = File.AppendText (System.IO.Path.Combine("logs",logFile));
             _FileStream.AutoFlush = true;
             _Bot = botName;
-            OutputToConsole = output;
+
+            OutputToLogfile = outputFile;
+            OutputToConsole = outputConsole;
             Console.ForegroundColor = DefaultConsoleColor;
         }
 
@@ -89,9 +92,9 @@ namespace SteamBot
                 DateTime.Now.ToString ("yyyy-MM-dd HH:mm:ss"),
                 _LogLevel (level).ToUpper (), line
                 );
-            _FileStream.WriteLine (formattedString);
-            if (level >= OutputToConsole)
-                _OutputLineToConsole (level, formattedString);
+
+            if( level >= OutputToLogfile ) _FileStream.WriteLine (formattedString);
+            if( level >= OutputToConsole ) _OutputLineToConsole (level, formattedString);
         }
 
         // Outputs a line to the console, with the correct color


### PR DESCRIPTION
Currently, the log file is written at LogLevel.Debug level despite the setting for LogLevel in the configuration file.
This pull adds the option to set a LogLevel for the console, and file separately, so debug information can be written to the console and not the log file, for example.
