### PR TITLE
Fix for issue #404 + added support for steamLoginSecure

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -87,6 +87,7 @@ namespace SteamBot
 
         string sessionId;
         string token;
+        string tokensecure;
         bool CookiesAreInvalid = true;
 
         bool isprocess;
@@ -618,7 +619,7 @@ namespace SteamBot
         {
             while (true)
             {
-                bool authd = SteamWeb.Authenticate(MyUniqueId, SteamClient, out sessionId, out token, MyUserNonce);
+                bool authd = SteamWeb.Authenticate(MyUniqueId, SteamClient, out sessionId, out token, out tokensecure, MyUserNonce);
 
                 if (authd)
                 {

--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -179,7 +179,7 @@ namespace SteamTrade
         /// This does the same as SteamWeb.DoLogin(), but without contacting the Steam Website.
         /// </summary> 
         /// <remarks>Should this one doesnt work anymore, use <see cref="SteamWeb.DoLogin"/></remarks>
-        public static bool Authenticate(string myUniqueId, SteamClient client, out string sessionId, out string token, string myLoginKey)
+        public static bool Authenticate(string myUniqueId, SteamClient client, out string sessionId, out string token, out string tokensecure, string myLoginKey)
         {
             sessionId = Convert.ToBase64String (Encoding.UTF8.GetBytes (myUniqueId));
             
@@ -210,16 +210,19 @@ namespace SteamTrade
                         steamid: client.SteamID.ConvertToUInt64 (),
                         sessionkey: HttpUtility.UrlEncode (cryptedSessionKey),
                         encrypted_loginkey: HttpUtility.UrlEncode (cryptedLoginKey),
-                        method: "POST"
+                        method: "POST",
+                        secure: true
                         );
                 }
                 catch (Exception)
                 {
                     token = null;
+                    tokensecure = null;
                     return false;
                 }
                 
                 token = authResult ["token"].AsString ();
+                tokensecure = authResult["tokensecure"].AsString();
                 
                 return true;
             }


### PR DESCRIPTION
The cookies become invalid if we login from another computer. Right now there is no mechanism to refresh these cookies (namely `sessionid` and `steamLogin`) and so the bot has to be restarted completely in order to be able to trade again.
