### PR TITLE
Compatibility with steam-nodejs sentry file format

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -657,12 +657,16 @@ namespace SteamBot
         void UserLogOn()
         {
             // get sentry file which has the machine hw info saved 
-            // from when a steam guard code was entered
+            // from when a steam guard code was entered.
+            // steam expects a SHA-1 hash of the sentry file contents
             Directory.CreateDirectory(System.IO.Path.Combine(System.Windows.Forms.Application.StartupPath, "sentryfiles"));
-            FileInfo fi = new FileInfo(System.IO.Path.Combine("sentryfiles", String.Format("{0}.sentryfile", logOnDetails.Username)));
+            FileInfo fiSentry = new FileInfo(System.IO.Path.Combine("sentryfiles", String.Format("{0}.sentryfile", logOnDetails.Username)));
+            FileInfo fiSentryHash = new FileInfo(System.IO.Path.Combine("sentryfiles", String.Format("{0}.hash.sentryfile", logOnDetails.Username)));
 
-            if (fi.Exists && fi.Length > 0)
-                logOnDetails.SentryFileHash = SHAHash(File.ReadAllBytes(fi.FullName));
+            if (fiSentry.Exists && fiSentry.Length > 0) 
+                logOnDetails.SentryFileHash = SHAHash(File.ReadAllBytes(fiSentry.FullName));
+            else if (fiSentryHash.Exists && fiSentryHash.Length > 0) // if we already have the hash, send it directly
+                logOnDetails.SentryFileHash = File.ReadAllBytes(fiSentryHash.FullName);
             else
                 logOnDetails.SentryFileHash = null;
 


### PR DESCRIPTION
(Sorry about that - let me try the pull request again.)

I am migrating from node-steam-trash-bot to SteamBot.
After authenticating with my bot account, there was a 7-day enforced delay on trade due to Steam Guard.
I figured I would just copy the steam sentry file from my node-steam-trash-bot installation, but it failed.

SteamBot (and Steam itself) hashes the contents of the sentry file. node-steam-trash-bot just saves the hash to the file.This change is to support both file formats.