### PR TITLE
Additional Steambot Error details

### DIFF
--- a/SteamBot/AdminUserHandler.cs
+++ b/SteamBot/AdminUserHandler.cs
@@ -87,7 +87,7 @@ namespace SteamBot
             return false;
         }
 
-        public override void OnTradeError(string error)
+        public override void OnTradeError(SteamBotError error)
         {
             Log.Error(error);
         }

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{E81DED36-EDF5-41A5-8666-A3A0C581762F}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>SteamBot</RootNamespace>
@@ -58,6 +60,18 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="SteamKit2, Version=1.6.2.38878, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\SteamKit2.1.6.2\lib\net40\SteamKit2.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
@@ -68,19 +82,12 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Management" />
     <Reference Include="System.Web" />
-    <Reference Include="MonoDevelop.CSharpBinding, Version=2.6.0.0, Culture=neutral" />
+    <Reference Include="MonoDevelop.CSharpBinding, Version=2.6.0.0, Culture=neutral">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
-    <Reference Include="protobuf-net">
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-    </Reference>
-    <Reference Include="SteamKit2">
-      <HintPath>..\packages\SteamKit2.1.6.2\lib\net40\SteamKit2.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Notifications.cs" />

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -1,10 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{E81DED36-EDF5-41A5-8666-A3A0C581762F}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>SteamBot</RootNamespace>
@@ -60,18 +58,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
-    </Reference>
-    <Reference Include="SteamKit2, Version=1.6.2.38878, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SteamKit2.1.6.2\lib\net40\SteamKit2.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
@@ -82,12 +68,19 @@
     <Reference Include="System.Numerics" />
     <Reference Include="System.Management" />
     <Reference Include="System.Web" />
-    <Reference Include="MonoDevelop.CSharpBinding, Version=2.6.0.0, Culture=neutral">
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="MonoDevelop.CSharpBinding, Version=2.6.0.0, Culture=neutral" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
+    <Reference Include="protobuf-net">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+    </Reference>
+    <Reference Include="SteamKit2">
+      <HintPath>..\packages\SteamKit2.1.6.2\lib\net40\SteamKit2.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.7\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Notifications.cs" />

--- a/SteamBot/SimpleUserHandler.cs
+++ b/SteamBot/SimpleUserHandler.cs
@@ -43,10 +43,10 @@ namespace SteamBot
             return true;
         }
         
-        public override void OnTradeError (string error) 
+        public override void OnTradeError (SteamBotError error) 
         {
-            SendChatMessage("Oh, there was an error: {0}.", error);
-            Bot.log.Warn (error);
+            SendChatMessage("Oh, there was an error: {0}.", error.getMessage());
+            Bot.log.Warn (error.getMessage());
         }
         
         public override void OnTradeTimeout () 

--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -49,10 +49,10 @@ namespace SteamBot
             return true;
         }
         
-        public override void OnTradeError (string error) 
+        public override void OnTradeError (SteamBotError error) 
         {
-            SendChatMessage("Oh, there was an error: {0}.", error);
-            Bot.log.Warn (error);
+            SendChatMessage("Oh, there was an error: {0}.", error.getMessage());
+            Bot.log.Warn (error.getMessage());
         }
         
         public override void OnTradeTimeout () 

--- a/SteamBot/TradeOfferUserHandler.cs
+++ b/SteamBot/TradeOfferUserHandler.cs
@@ -104,7 +104,7 @@ namespace SteamBot
 
         public override bool OnTradeRequest() { return false; }
 
-        public override void OnTradeError(string error) { }
+        public override void OnTradeError(SteamBotError error) { }
 
         public override void OnTradeTimeout() { }
 

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -196,17 +196,18 @@ namespace SteamBot
         public abstract void OnTradeError (SteamBotError error);
 
         public virtual void OnStatusError (Trade.TradeStatusType status)
-		{
-			string otherUserName = Bot.SteamFriends.GetFriendPersonaName (OtherSID);
-			string statusMessage = (Trade != null ? Trade.GetTradeStatusErrorString (status) : "died a horrible death");
-			string errorMessage = String.Format ("Trade with {0} ({1}) {2}", otherUserName, OtherSID.ConvertToUInt64 (), statusMessage);
-			SteamBotError.SteamBotErrorType errorType = SteamBotError.SteamBotErrorType.UNKNOWN;
-			if (status = Trade.TradeStatusType.TradeCancelled) {
-				errorType = SteamBotError.SteamBotErrorType.TRADE_CANCELED_BY_USER;
-			} else if (status = Trade.TradeStatusType.SessionExpired) {
-				errorType = SteamBotError.SteamBotErrorType.TRADE_SESSION_EXPIRED;
-			}
-            OnTradeError(new SteamBotError(errorMessage, errorType));
+        {
+            string otherUserName = Bot.SteamFriends.GetFriendPersonaName (OtherSID);
+            string statusMessage = (Trade != null ? Trade.GetTradeStatusErrorString (status) : "died a horrible death");
+            string errorMessage = String.Format ("Trade with {0} ({1}) {2}", otherUserName, OtherSID.ConvertToUInt64 (), statusMessage);
+            SteamBotError.SteamBotErrorType errorType = SteamBotError.SteamBotErrorType.UNKNOWN;
+            if (status = Trade.TradeStatusType.TradeCancelled) {
+                errorType = SteamBotError.SteamBotErrorType.TRADE_CANCELED_BY_USER;
+            }
+            else if (status = Trade.TradeStatusType.SessionExpired) {
+                errorType = SteamBotError.SteamBotErrorType.TRADE_SESSION_EXPIRED;
+            }
+            OnTradeError (new SteamBotError (errorMessage, errorType));
         }
 
         public abstract void OnTradeTimeout ();

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -193,14 +193,20 @@ namespace SteamBot
         #region Trade events
         // see the various events in SteamTrade.Trade for descriptions of these handlers.
 
-        public abstract void OnTradeError (string error);
+        public abstract void OnTradeError (SteamBotError error);
 
-        public virtual void OnStatusError(Trade.TradeStatusType status)
-        {
-            string otherUserName = Bot.SteamFriends.GetFriendPersonaName(OtherSID);
-            string statusMessage = (Trade != null ? Trade.GetTradeStatusErrorString(status) : "died a horrible death");
-            string errorMessage = String.Format("Trade with {0} ({1}) {2}", otherUserName, OtherSID.ConvertToUInt64(), statusMessage);
-            OnTradeError(errorMessage);
+        public virtual void OnStatusError (Trade.TradeStatusType status)
+		{
+			string otherUserName = Bot.SteamFriends.GetFriendPersonaName (OtherSID);
+			string statusMessage = (Trade != null ? Trade.GetTradeStatusErrorString (status) : "died a horrible death");
+			string errorMessage = String.Format ("Trade with {0} ({1}) {2}", otherUserName, OtherSID.ConvertToUInt64 (), statusMessage);
+			SteamBotError.SteamBotErrorType errorType = SteamBotError.SteamBotErrorType.UNKNOWN;
+			if (status = Trade.TradeStatusType.TradeCancelled) {
+				errorType = SteamBotError.SteamBotErrorType.TRADE_CANCELED_BY_USER;
+			} else if (status = Trade.TradeStatusType.SessionExpired) {
+				errorType = SteamBotError.SteamBotErrorType.TRADE_SESSION_EXPIRED;
+			}
+            OnTradeError(new SteamBotError(errorMessage, errorType));
         }
 
         public abstract void OnTradeTimeout ();

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -202,9 +202,9 @@ namespace SteamBot
             string errorMessage = String.Format ("Trade with {0} ({1}) {2}", otherUserName, OtherSID.ConvertToUInt64 (), statusMessage);
             SteamBotError.SteamBotErrorType errorType = SteamBotError.SteamBotErrorType.UNKNOWN;
             if (status = Trade.TradeStatusType.TradeCancelled) {
-                errorType = SteamBotError.SteamBotErrorType.TRADE_CANCELED_BY_USER;
+                errorType == SteamBotError.SteamBotErrorType.TRADE_CANCELED_BY_USER;
             }
-            else if (status = Trade.TradeStatusType.SessionExpired) {
+            else if (status == Trade.TradeStatusType.SessionExpired) {
                 errorType = SteamBotError.SteamBotErrorType.TRADE_SESSION_EXPIRED;
             }
             OnTradeError (new SteamBotError (errorMessage, errorType));

--- a/SteamTrade/SteamBotError.cs
+++ b/SteamTrade/SteamBotError.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace SteamTrade
+{
+    public class SteamBotError
+    {
+        SteamBotErrorType type;
+        string message;
+
+        public SteamBotError (string message, SteamBotErrorType type = SteamBotErrorType.DEFAULT)
+        {
+            this.type = type;
+            this.message = message;
+        }
+
+        public SteamBotErrorType getErrorType(){
+            return type;
+        }
+
+        public string getMessage(){
+            return message;
+        }
+
+        public enum SteamBotErrorType{
+			DEFAULT,
+            INVENTORY_PRIVATE,
+            TRADE_CANCELED_BY_USER,
+			TRADE_SESSION_EXPIRED,
+            UNKNOWN
+        }
+    }
+}
+

--- a/SteamTrade/SteamBotError.cs
+++ b/SteamTrade/SteamBotError.cs
@@ -4,8 +4,8 @@ namespace SteamTrade
 {
     public class SteamBotError
     {
-        SteamBotErrorType type;
-        string message;
+        SteamBotErrorType type { get; private set; }
+        string message { get; private set; }
 
         public SteamBotError (string message, SteamBotErrorType type = SteamBotErrorType.DEFAULT)
         {
@@ -13,21 +13,13 @@ namespace SteamTrade
             this.message = message;
         }
 
-        public SteamBotErrorType getErrorType(){
-            return type;
-        }
-
-        public string getMessage(){
-            return message;
-        }
-
-        public enum SteamBotErrorType{
-			DEFAULT,
+        public enum SteamBotErrorType
+        {
+            DEFAULT,
             INVENTORY_PRIVATE,
             TRADE_CANCELED_BY_USER,
-			TRADE_SESSION_EXPIRED,
+            TRADE_SESSION_EXPIRED,
             UNKNOWN
         }
     }
 }
-

--- a/SteamTrade/SteamBotError.cs
+++ b/SteamTrade/SteamBotError.cs
@@ -4,8 +4,8 @@ namespace SteamTrade
 {
     public class SteamBotError
     {
-        SteamBotErrorType type { get; private set; }
-        string message { get; private set; }
+        public SteamBotErrorType type { get; private set; }
+        public string message { get; private set; }
 
         public SteamBotError (string message, SteamBotErrorType type = SteamBotErrorType.DEFAULT)
         {

--- a/SteamTrade/SteamTrade.csproj
+++ b/SteamTrade/SteamTrade.csproj
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{6CEC0333-81EB-40EE-85D1-941363626FC7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>SteamTrade</RootNamespace>

--- a/SteamTrade/SteamTrade.csproj
+++ b/SteamTrade/SteamTrade.csproj
@@ -1,10 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{6CEC0333-81EB-40EE-85D1-941363626FC7}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>SteamTrade</RootNamespace>
@@ -67,6 +65,7 @@
     <Compile Include="TradeWebAPI\TradeSession.cs" />
     <Compile Include="TradeManager.cs" />
     <Compile Include="Exceptions\InventoryFetchException.cs" />
+    <Compile Include="SteamBotError.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -201,7 +201,7 @@ namespace SteamTrade
 
         public delegate void CompleteHandler();
 
-        public delegate void ErrorHandler(string errorMessage);
+        public delegate void ErrorHandler(SteamBotError errorMessage);
 
         public delegate void StatusErrorHandler(TradeStatusType statusType);
 
@@ -841,7 +841,7 @@ namespace SteamTrade
             var onErrorEvent = OnError;
 
             if(onErrorEvent != null)
-                onErrorEvent(message);
+                onErrorEvent(new SteamBotError(message, SteamBotError.SteamBotErrorType.UNKNOWN));
         }
 
         internal void FireOnStatusErrorEvent(TradeStatusType statusType)


### PR DESCRIPTION
Allows additional information on errors. Added a SteamBotError class to allow for more information to be given with errors, making dynamic responses possible for when something fails.

If anyone knows were to put the SteamBotErrorType.INVENTORY_PRIVATE error the help would be appreciated.

Note: I was going to have it in SteamBot but Trade.cs requires it as a
dependency forcing me to move it to SteamTrade.