### PR TITLE
Added GetUserResponse() method

### DIFF
--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -21,6 +21,7 @@ namespace SteamBot
 
         private bool _lastMessageWasFromTrade;
         private Task<Inventory> otherInventoryTask;
+        private TaskCompletionSource<string> _waitingOnUserResponse;
 
         protected SteamWeb SteamWeb
         {
@@ -39,6 +40,16 @@ namespace SteamBot
             Bot = bot;
             OtherSID = sid;
             GetOtherInventory();
+        }
+
+        private bool HandleWaitingOnUserResponse(string message)
+        {
+            if(_waitingOnUserResponse == null)
+                return false;
+
+            _waitingOnUserResponse.SetResult(message);
+            _waitingOnUserResponse = null;
+            return true;
         }
 
         /// <summary>
@@ -133,9 +144,11 @@ namespace SteamBot
         public void OnMessageHandler(string message, EChatEntryType type)
         {
             _lastMessageWasFromTrade = false;
-            OnMessage(message, type);
+            if(!HandleWaitingOnUserResponse(message))
+            {
+                OnMessage(message, type);
+            }
         }
-
 
         /// <summary>
         /// Called when the bot is fully logged in.
@@ -190,6 +203,26 @@ namespace SteamBot
 
         }
 
+        /// <summary>
+        /// Waits for the user to enter something into regular or trade chat, then returns it (as the result of a task)
+        /// Usage: The following displays "How many do you want to buy" and stores the user's response:
+        /// string userResponse = await GetUserResponse("How many do you want to buy?");
+        /// 
+        /// Note: calling this method causes the next user-message to NOT call OnMessage() or OnTradeMessage()
+        /// </summary>
+        /// <param name="message">An option message to display to the user.
+        /// Sent to whichever chat (normal or trade) is currently being used.</param>
+        protected virtual Task<string> GetUserResponse(string message = null)
+        {
+            if (message != null)
+            {
+                SendReplyMessage(message);
+            }
+
+            _waitingOnUserResponse = new TaskCompletionSource<string>();
+            return _waitingOnUserResponse.Task;
+        }
+
         #region Trade events
         // see the various events in SteamTrade.Trade for descriptions of these handlers.
 
@@ -221,7 +254,10 @@ namespace SteamBot
         public void OnTradeMessageHandler(string message)
         {
             _lastMessageWasFromTrade = true;
-            OnTradeMessage(message);
+            if (!HandleWaitingOnUserResponse(message))
+            {
+                OnTradeMessage(message);
+            }
         }
 
         public abstract void OnTradeMessage (string message);


### PR DESCRIPTION
I figured this would be a good place to start introducing `await` into the codebase.  It's a non-breaking addition.  The method can be used like this:

    public override async void OnMessage(string message, EChatEntryType type)
    {
        if(message.StartsWith("buy", StringComparison.CurrentCultureIgnoreCase))
        {
            //The following sends the message "How many do you want to buy?" to the user,
            //then returns their response
            string response = await GetUserResponse("How many do you want to buy?");
            //Call int.TryParse(), etc.
        }
    }