### PR TITLE
Add exception on access to private inventory

### DIFF
--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -71,11 +71,19 @@ namespace SteamTrade
 
         public Item GetItem (ulong id)
         {
+            // Check for Private Inventory
+            if( this.IsPrivate )
+                throw new Exceptions.TradeException("Unable to access Inventory: Inventory is Private!");
+
             return (Items == null ? null : Items.FirstOrDefault(item => item.Id == id));
         }
 
         public List<Item> GetItemsByDefindex (int defindex)
         {
+            // Check for Private Inventory
+            if( this.IsPrivate )
+                throw new Exceptions.TradeException("Unable to access Inventory: Inventory is Private!");
+
             return Items.Where(item => item.Defindex == defindex).ToList();
         }
 
@@ -161,7 +169,6 @@ namespace SteamTrade
         {
             public InventoryResult result;
         }
-
     }
 }
 


### PR DESCRIPTION
As per Issue #704.
This throws a more meaningful exception. However, it will still wait until an item is added to throw it.

If it is wanted, the commented code linked below could be used to throw a warning when a trade is opened saying the backpack is private, but that depends on what is desired. Do we want to prevent trades when the bot has a private backpack?
@BlueRaja 

https://github.com/Jessecar96/SteamBot/blob/master/SteamBot/Bot.cs#L574

For example, the following block could be added into the above callback:

```
if (tradeManager.MyInventory.IsPrivate)
{
    // Check if the bot's backpack is private
    log.Warn("The bot's backpack is private! If your bot adds any items it will fail! Your bot's backpack should be Friends Only or Public.");
}
```