### PR TITLE
Fixed MonoDevelop issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Ankh.NoLoad
 #OS junk files
 [Tt]humbs.db
 *.DS_Store
+push.sh
 
 *.userprefs
 *.pidb

--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -54,7 +54,7 @@
 		<SolutionDirParsed Condition=" '$(OS)' == 'Windows_NT' ">$(SolutionDir) </SolutionDirParsed>
         <SolutionDirParsed Condition=" '$(OS)' != 'Windows_NT' ">$(SolutionDir)</SolutionDirParsed>
         <RestoreCommand Condition=" '$(OS)' == 'Windows_NT' ">$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(RequireConsentSwitch) -solutionDir "$(SolutionDirParsed)"</RestoreCommand>
-        <RestoreCommand Condition=" '$(OS)' != 'Windows_NT' ">bash $(NuGetToolsPath)\..\.ci\exec-with-retry.sh $(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(RequireConsentSwitch) -solutionDir "$(SolutionDirParsed)"</RestoreCommand>
+        <RestoreCommand Condition=" '$(OS)' != 'Windows_NT' ">bash "$(NuGetToolsPath)\..\.ci\exec-with-retry.sh" $(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(RequireConsentSwitch) -solutionDir "$(SolutionDirParsed)"</RestoreCommand>
       
         <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties Configuration=$(Configuration) $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
 


### PR DESCRIPTION
If you tried to build the solution with MonoDevelop( in a linux based OS) and the solution was inside a folder that had a space in the name it'd fail.

Minor fix by adding "" to the path.