### PR TITLE
Trade Event 6 - UserSetCurrency

### DIFF
--- a/SteamTrade/TradeWebAPI/TradeStatus.cs
+++ b/SteamTrade/TradeWebAPI/TradeStatus.cs
@@ -190,7 +190,7 @@ namespace SteamTrade.TradeWebAPI
         UserSetUnReady = 3,
         UserAccept = 4,
         //5 = ?? Maybe some sort of cancel?
-        //6 = ??
+        UserSetCurrency = 6,
         UserChat = 7 //message = "text"
     }
 }


### PR DESCRIPTION
Based on go-steam's tradeapi eventlist:
const (
    Action_AddItem     Action = 0
    Action_RemoveItem         = 1
    Action_Ready              = 2
    Action_Unready            = 3
    Action_Accept             = 4
    Action_SetCurrency        = 6
    Action_ChatMessage        = 7
)
Adding "Spiral Knights Crowns" causes an exception like the one below:
00:22 - [BOT] Shaun The Sheep: Trade ended: Unknown error occurred: SteamTrade.Exceptions.TradeException: Unknown event type: 6
   w SteamTrade.Trade.HandleTradeOngoing(TradeStatus status) w X:\SteamBot-master\SteamTrade\Trade.cs:line 673
   w SteamTrade.Trade.Poll() w X:\SteamBot-master\SteamTrade\Trade.cs:line 575
   w SteamTrade.TradeManager.<>c__DisplayClass6.<StartTradeThread>b__5() w X:\SteamBot-master\SteamTrade\TradeManager.cs:line 264.
After making changes I committed in this PR, the error no longer occurs. It's not bot-breaking, however users can kill their trades with this. Happens with *MOST* currencies