### PR TITLE
Null item array patch

### DIFF
--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -19,7 +19,7 @@ namespace SteamTrade
         {
             int attempts = 1;
             InventoryResponse result = null;
-            while ((result.result.items == null || result == null) && attempts <= 3)
+            while ((result == null || result.result.items == null) && attempts <= 3)
             {
                 var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
                 string response = steamWeb.Fetch(url, "GET", null, false);

--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -15,11 +15,17 @@ namespace SteamTrade
         /// <param name='steamId'>Steam identifier.</param>
         /// <param name='apiKey'>The needed Steam API key.</param>
         /// <param name="steamWeb">The SteamWeb instance for this Bot</param>
-        public static Inventory FetchInventory (ulong steamId, string apiKey, SteamWeb steamWeb)
+        public static Inventory FetchInventory(ulong steamId, string apiKey, SteamWeb steamWeb)
         {
-            var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
-            string response = steamWeb.Fetch (url, "GET", null, false);
-            InventoryResponse result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+            int attempts = 1;
+            InventoryResponse result = null;
+            while ((result.result.items == null || result == null) && attempts <= 3)
+            {
+                var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
+                string response = steamWeb.Fetch(url, "GET", null, false);
+                result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+                attempts++;
+            }
             return new Inventory(result.result);
         }
 


### PR DESCRIPTION
Prevents a malformed server response from being processed - a empty 200 OK response happens randomly from time to time on all sorts of TF2 (and propably non-TF2 as well) inventories - this will fetch the inventory three times (if it's still null) before returning an object.
If it's not the perfect way to go - correct me, please. Exceptions raised while attempting to process a malformed inventory like one mentioned of course kills the trade instantly.
This somewhat fixes #731.