### PR TITLE
Fixing Inventories, and Trade Offers.

### DIFF
--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -23,18 +23,11 @@ namespace SteamTrade
             {
                 var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
                 string response = steamWeb.Fetch(url, "GET", null, false);
-                try
-                {
-                    result = JsonConvert.DeserializeObject<InventoryResponse>(response);
-                }
-                catch (Exception e)
-                {
-
-                }
+                result = JsonConvert.DeserializeObject<InventoryResponse>(response);
                 attempts++;
             }
             if (result == null || result.result == null || result.result.items == null)
-                return new Inventory(new InventoryResult());
+                throw Exception("Cannot fetch inventory of user #" + steamId);
             return new Inventory(result.result);
         }
 

--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -15,11 +15,26 @@ namespace SteamTrade
         /// <param name='steamId'>Steam identifier.</param>
         /// <param name='apiKey'>The needed Steam API key.</param>
         /// <param name="steamWeb">The SteamWeb instance for this Bot</param>
-        public static Inventory FetchInventory (ulong steamId, string apiKey, SteamWeb steamWeb)
+        public static Inventory FetchInventory(ulong steamId, string apiKey, SteamWeb steamWeb)
         {
-            var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
-            string response = steamWeb.Fetch (url, "GET", null, false);
-            InventoryResponse result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+            int attempts = 1;
+            InventoryResponse result = null;
+            while ((result == null || result.result == null || result.result.items == null) && attempts <= 5)
+            {
+                var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
+                string response = steamWeb.Fetch(url, "GET", null, false);
+                try
+                {
+                    result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+                }
+                catch (Exception e)
+                {
+
+                }
+                attempts++;
+            }
+            if (result == null || result.result == null || result.result.items == null)
+                return new Inventory(new InventoryResult());
             return new Inventory(result.result);
         }
 

--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -54,16 +54,9 @@ namespace SteamTrade.TradeOffer
                     var tradeAsset = new TradeStatusUser.TradeAsset();
                     //todo: for currency items we need to check descriptions for currency bool and use the appropriate method
                     tradeAsset.CreateItemAsset(Convert.ToInt64(asset.AppId), Convert.ToInt64(asset.ContextId),
-                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount));
+                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount), asset.IsMissing);
                     //todo: for missing assets we should store them somewhere else? if offer state is active we shouldn't be here though
-                    if (!asset.IsMissing)
-                    {
-                        myAssets.Add(tradeAsset);
-                    }
-                    else
-                    {
-                        myMissingAssets.Add(tradeAsset);
-                    }
+                    myAssets.Add(tradeAsset);
                 }
             }
             if (offer.ItemsToReceive != null)
@@ -73,14 +66,7 @@ namespace SteamTrade.TradeOffer
                     var tradeAsset = new TradeStatusUser.TradeAsset();
                     tradeAsset.CreateItemAsset(Convert.ToInt64(asset.AppId), Convert.ToInt64(asset.ContextId),
                         Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount));
-                    if (!asset.IsMissing)
-                    {
-                        theirAssets.Add(tradeAsset);
-                    }
-                    else
-                    {
-                        theirMissingAssets.Add(tradeAsset);
-                    }
+                    theirAssets.Add(tradeAsset);
                 }
             }
             this.Session = session;

--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -54,9 +54,16 @@ namespace SteamTrade.TradeOffer
                     var tradeAsset = new TradeStatusUser.TradeAsset();
                     //todo: for currency items we need to check descriptions for currency bool and use the appropriate method
                     tradeAsset.CreateItemAsset(Convert.ToInt64(asset.AppId), Convert.ToInt64(asset.ContextId),
-                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount), asset.IsMissing);
+                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount));
                     //todo: for missing assets we should store them somewhere else? if offer state is active we shouldn't be here though
-                    myAssets.Add(tradeAsset);
+                    if (!asset.IsMissing)
+                    {
+                        myAssets.Add(tradeAsset);
+                    }
+                    else
+                    {
+                        myMissingAssets.Add(tradeAsset);
+                    }
                 }
             }
             if (offer.ItemsToReceive != null)
@@ -65,8 +72,15 @@ namespace SteamTrade.TradeOffer
                 {
                     var tradeAsset = new TradeStatusUser.TradeAsset();
                     tradeAsset.CreateItemAsset(Convert.ToInt64(asset.AppId), Convert.ToInt64(asset.ContextId),
-                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount), asset.IsMissing);
-                    theirAssets.Add(tradeAsset);
+                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount));
+                    if (!asset.IsMissing)
+                    {
+                        theirAssets.Add(tradeAsset);
+                    }
+                    else
+                    {
+                        theirMissingAssets.Add(tradeAsset);
+                    }
                 }
             }
             this.Session = session;
@@ -105,7 +119,7 @@ namespace SteamTrade.TradeOffer
         /// <param name="offerId">The trade offer id if successully created</param>
         /// <param name="message">Optional message to included with the trade offer</param>
         /// <returns>true if successfully sent, otherwise false</returns>
-        public int Send(out string offerId, string message = "")
+        public bool Send(out string offerId, string message = "")
         {
             offerId = String.Empty;
             if (TradeOfferId == null)
@@ -114,7 +128,7 @@ namespace SteamTrade.TradeOffer
             }
             //todo: log
             Debug.WriteLine("Can't send a trade offer that already exists.");
-            return 0;
+            return false;
         }
 
         /// <summary>
@@ -124,16 +138,16 @@ namespace SteamTrade.TradeOffer
         /// <param name="token">The token of the partner</param>
         /// <param name="message">Optional message to included with the trade offer</param>
         /// <returns></returns>
-        public int SendWithToken(out string offerId, string token, string message = "", bool debug = false)
+        public bool SendWithToken(out string offerId, string token, string message = "")
         {
             offerId = String.Empty;
             if (TradeOfferId == null)
             {
-                return Session.SendTradeOfferWithToken(message, PartnerSteamId, this.Items, token, out offerId, debug);
+                return Session.SendTradeOfferWithToken(message, PartnerSteamId, this.Items, token, out offerId);
             }
             //todo: log
             Debug.WriteLine("Can't send a trade offer that already exists.");
-            return 0;
+            return false;
         }
 
         /// <summary>

--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using SteamKit2;
 using System;
 using System.Collections.Generic;
@@ -105,7 +105,7 @@ namespace SteamTrade.TradeOffer
         /// <param name="offerId">The trade offer id if successully created</param>
         /// <param name="message">Optional message to included with the trade offer</param>
         /// <returns>true if successfully sent, otherwise false</returns>
-        public bool Send(out string offerId, string message = "")
+        public int Send(out string offerId, string message = "")
         {
             offerId = String.Empty;
             if (TradeOfferId == null)
@@ -114,7 +114,7 @@ namespace SteamTrade.TradeOffer
             }
             //todo: log
             Debug.WriteLine("Can't send a trade offer that already exists.");
-            return false;
+            return 0;
         }
 
         /// <summary>
@@ -124,16 +124,16 @@ namespace SteamTrade.TradeOffer
         /// <param name="token">The token of the partner</param>
         /// <param name="message">Optional message to included with the trade offer</param>
         /// <returns></returns>
-        public bool SendWithToken(out string offerId, string token, string message = "")
+        public int SendWithToken(out string offerId, string token, string message = "", bool debug = false)
         {
             offerId = String.Empty;
             if (TradeOfferId == null)
             {
-                return Session.SendTradeOfferWithToken(message, PartnerSteamId, this.Items, token, out offerId);
+                return Session.SendTradeOfferWithToken(message, PartnerSteamId, this.Items, token, out offerId, debug);
             }
             //todo: log
             Debug.WriteLine("Can't send a trade offer that already exists.");
-            return false;
+            return 0;
         }
 
         /// <summary>
@@ -262,56 +262,56 @@ namespace SteamTrade.TradeOffer
             public bool AddMyItem(int appId, long contextId, long assetId, long amount = 1)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateItemAsset(appId, contextId, assetId, amount);
+                asset.CreateItemAsset(appId, contextId, assetId, amount, false);
                 return ShouldUpdate(MyOfferedItems.AddItem(asset));
             }
 
             public bool AddTheirItem(int appId, long contextId, long assetId, long amount = 1)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateItemAsset(appId, contextId, assetId, amount);
+                asset.CreateItemAsset(appId, contextId, assetId, amount, false);
                 return ShouldUpdate(TheirOfferedItems.AddItem(asset));
             }
 
             public bool AddMyCurrencyItem(int appId, long contextId, long currencyId, long amount)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount);
+                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount, false);
                 return ShouldUpdate(MyOfferedItems.AddCurrencyItem(asset));
             }
 
             public bool AddTheirCurrencyItem(int appId, long contextId, long currencyId, long amount)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount);
+                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount, false);
                 return ShouldUpdate(TheirOfferedItems.AddCurrencyItem(asset));
             }
 
             public bool RemoveMyItem(int appId, long contextId, long assetId, long amount = 1)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateItemAsset(appId, contextId, assetId, amount);
+                asset.CreateItemAsset(appId, contextId, assetId, amount, false);
                 return ShouldUpdate(MyOfferedItems.RemoveItem(asset));
             }
 
             public bool RemoveTheirItem(int appId, long contextId, long assetId, long amount = 1)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateItemAsset(appId, contextId, assetId, amount);
+                asset.CreateItemAsset(appId, contextId, assetId, amount, false);
                 return ShouldUpdate(TheirOfferedItems.RemoveItem(asset));
             }
 
             public bool RemoveMyCurrencyItem(int appId, long contextId, long currencyId, long amount)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount);
+                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount, false);
                 return ShouldUpdate(MyOfferedItems.RemoveCurrencyItem(asset));
             }
 
             public bool RemoveTheirCurrencyItem(int appId, long contextId, long currencyId, long amount)
             {
                 var asset = new TradeStatusUser.TradeAsset();
-                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount);
+                asset.CreateCurrencyAsset(appId, contextId, currencyId, amount, false);
                 return ShouldUpdate(TheirOfferedItems.RemoveCurrencyItem(asset));
             }
 
@@ -517,11 +517,11 @@ namespace SteamTrade.TradeOffer
 
                 [JsonProperty("currencyid"), JsonConverter(typeof(ValueStringConverter))]
                 public long CurrencyId { get; set; }
-                
+
                 [JsonProperty("missing")]
                 public bool IsMissing { get; set; }
 
-                public void CreateItemAsset(long appId, long contextId, long assetId, long amount, bool missing = false)
+                public void CreateItemAsset(long appId, long contextId, long assetId, long amount, bool missing)
                 {
                     this.AppId = appId;
                     this.ContextId = contextId;
@@ -531,13 +531,14 @@ namespace SteamTrade.TradeOffer
                     this.IsMissing = missing;
                 }
 
-                public void CreateCurrencyAsset(long appId, long contextId, long currencyId, long amount)
+                public void CreateCurrencyAsset(long appId, long contextId, long currencyId, long amount, bool missing)
                 {
                     this.AppId = appId;
                     this.ContextId = contextId;
                     this.CurrencyId = currencyId;
                     this.Amount = amount;
                     this.AssetId = 0;
+                    this.IsMissing = missing;
                 }
 
                 public bool ShouldSerializeAssetId()

--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -65,7 +65,7 @@ namespace SteamTrade.TradeOffer
                 {
                     var tradeAsset = new TradeStatusUser.TradeAsset();
                     tradeAsset.CreateItemAsset(Convert.ToInt64(asset.AppId), Convert.ToInt64(asset.ContextId),
-                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount));
+                        Convert.ToInt64(asset.AssetId), Convert.ToInt64(asset.Amount), asset.IsMissing);
                     theirAssets.Add(tradeAsset);
                 }
             }

--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -517,14 +517,18 @@ namespace SteamTrade.TradeOffer
 
                 [JsonProperty("currencyid"), JsonConverter(typeof(ValueStringConverter))]
                 public long CurrencyId { get; set; }
+                
+                [JsonProperty("missing")]
+                public bool IsMissing { get; set; }
 
-                public void CreateItemAsset(long appId, long contextId, long assetId, long amount)
+                public void CreateItemAsset(long appId, long contextId, long assetId, long amount, bool missing = false)
                 {
                     this.AppId = appId;
                     this.ContextId = contextId;
                     this.AssetId = assetId;
                     this.Amount = amount;
                     this.CurrencyId = 0;
+                    this.IsMissing = missing;
                 }
 
                 public void CreateCurrencyAsset(long appId, long contextId, long currencyId, long amount)

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -168,7 +168,6 @@ namespace SteamTrade.TradeOffer
                 {
                     //todo: log steam api is giving us invalid offers.
                     Debug.WriteLine("Received invalid offer from Steam API");
-//                    Logging.Log("resp.Offer stringified: ->" + (resp.Offer == null ? "Null" : resp.Offer.ToString()), Logging.LogLevel.ERROR);
                 }
             }
             else

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -167,8 +167,13 @@ namespace SteamTrade.TradeOffer
                 else
                 {
                     //todo: log steam api is giving us invalid offers.
-                    Debug.WriteLine("Offer returned from steam api is not valid : " + resp.Offer.TradeOfferId);
+                    Debug.WriteLine("Received invalid offer from Steam API");
+//                    Logging.Log("resp.Offer stringified: ->" + (resp.Offer == null ? "Null" : resp.Offer.ToString()), Logging.LogLevel.ERROR);
                 }
+            }
+            else
+            {
+                Debug.WriteLine("Null TradeOffer response!");
             }
             return false;
         }


### PR DESCRIPTION
Fixing the following:
1. Empty/null inventories.
2. Trade Offers generated without all items (omitting "missing" assets for no reason)
The missing assets should be added to the trade offers for user's verification for instance when an offer goes "Invalid", a user might want to know which items went missing to re-offer, right? Well the missing assets were omitted and lost while converting a JSON response to a TradeOffer class.
3. Added a nullcheck for the response in TradeOfferManager - so SteamBot doesn't crash after receiving an empty response which - let's be honest - happens a lot with Steam.