### PR TITLE
Fixing Inventories, and Trade Offers, attempt 2

### DIFF
--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -15,11 +15,19 @@ namespace SteamTrade
         /// <param name='steamId'>Steam identifier.</param>
         /// <param name='apiKey'>The needed Steam API key.</param>
         /// <param name="steamWeb">The SteamWeb instance for this Bot</param>
-        public static Inventory FetchInventory (ulong steamId, string apiKey, SteamWeb steamWeb)
+        public static Inventory FetchInventory(ulong steamId, string apiKey, SteamWeb steamWeb)
         {
-            var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
-            string response = steamWeb.Fetch (url, "GET", null, false);
-            InventoryResponse result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+            int attempts = 1;
+            InventoryResponse result = null;
+            while ((result == null || result.result == null || result.result.items == null) && attempts <= 5)
+            {
+                var url = "http://api.steampowered.com/IEconItems_440/GetPlayerItems/v0001/?key=" + apiKey + "&steamid=" + steamId;
+                string response = steamWeb.Fetch(url, "GET", null, false);
+                result = JsonConvert.DeserializeObject<InventoryResponse>(response);
+                attempts++;
+            }
+            if (result == null || result.result == null || result.result.items == null)
+                throw Exception("Cannot fetch inventory of user #" + steamId);
             return new Inventory(result.result);
         }
 

--- a/SteamTrade/Inventory.cs
+++ b/SteamTrade/Inventory.cs
@@ -27,7 +27,7 @@ namespace SteamTrade
                 attempts++;
             }
             if (result == null || result.result == null || result.result.items == null)
-                throw Exception("Cannot fetch inventory of user #" + steamId);
+                throw new Exception("Cannot fetch inventory of user #" + steamId);
             return new Inventory(result.result);
         }
 

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics;
 using SteamKit2;
 using System;
@@ -167,8 +167,12 @@ namespace SteamTrade.TradeOffer
                 else
                 {
                     //todo: log steam api is giving us invalid offers.
-                    Debug.WriteLine("Offer returned from steam api is not valid : " + resp.Offer.TradeOfferId);
+                    Debug.WriteLine("Received invalid offer from Steam API");
                 }
+            }
+            else
+            {
+                Debug.WriteLine("Null TradeOffer response!");
             }
             return false;
         }


### PR DESCRIPTION
This time all of the stuff I mentioned in the previous PR is fixed, and everything is nicely compressed into a "one-commit-per-file-changed" form.
Again, recapping what this does:
1. If received an invalid inventory - downloading will be retried a few times before continuing.
2. TradeOfferManager didn't nullcheck when fetching a single offer - fixed.
3. Offer -> TradeOffer conversion didn't include missing assets, making checking "which side's items went missing" impossible. Fixed as well.