### PR TITLE
Added in Message to TradeOffers

### DIFF
--- a/SteamTrade/TradeOffer/TradeOffer.cs
+++ b/SteamTrade/TradeOffer/TradeOffer.cs
@@ -26,6 +26,8 @@ namespace SteamTrade.TradeOffer
         public int ExpirationTime { get; private set; }
 
         public int TimeUpdated { get; private set; }
+        
+        public string Message { get; private set; }
 
         public bool IsFirstOffer
         {
@@ -92,6 +94,7 @@ namespace SteamTrade.TradeOffer
             ExpirationTime = offer.ExpirationTime;
             TimeCreated = offer.TimeCreated;
             TimeUpdated = TimeUpdated;
+            Message = offer.Message;
             Items = new TradeStatus(myAssets, theirAssets);
         }
 


### PR DESCRIPTION
This will allow you to see what message the user has typed in the comment box when they send a message. 
All you would have to do is call offer.Message under the OnNewTradeOffer method.  Example
Log.warn("Trade Offer Message = " + offer.Message)
Would the log the Message that is included in the trade offer.

I feel like i need to add an example into the TradeOfferUserHandler but not sure what example to put.

I am sorry if this was already included in the code somewhere but i looked around multiple times and could not find another way to do it.