### PR TITLE
Fix NullReferenceException when stopping bot

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -927,6 +927,8 @@ namespace SteamBot
                 StopBot(); //disposes log
                 //StartBot();
             }
+            
+            DisposeLog();
 
         }
 

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -924,11 +924,10 @@ namespace SteamBot
                 Log.Info("This bot died. Stopping it..");
                 //backgroundWorker.RunWorkerAsync();
                 //Thread.Sleep(10000);
-                StopBot();
+                StopBot(); //disposes log
                 //StartBot();
             }
 
-            Log.Dispose();
         }
 
         private void BackgroundWorkerOnDoWork(object sender, DoWorkEventArgs doWorkEventArgs)


### PR DESCRIPTION
The log is already disposed in StopBot(), repeating it afterwards throws a NullReferenceException, so I have removed the reference to Log.Dispose() below StopBot()