### PR TITLE
Threaded steam web

### DIFF
--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -58,8 +58,8 @@ namespace SteamTrade
 
         public HttpWebResponse Request(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
-            Task<WebResponse> responseTask = RequestAsync(url, method, data, ajax, referer);
-            return responseTask.Result as HttpWebResponse;
+            Task<WebResponse> requestTask = Task.Run(async() => { return await RequestAsync(url, method, data, ajax, referer); });
+            return requestTask.Result as HttpWebResponse;
         }
 
         public Task<string> FetchAsync(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
@@ -75,8 +75,8 @@ namespace SteamTrade
 
         public string Fetch(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
-            Task<string> responseTask = FetchAsync(url, method, data, ajax, referer);
-            return responseTask.Result;
+            Task<string> fetchTask = Task.Run(async() => { return await FetchAsync(url, method, data, ajax, referer)});
+            return fetchTask.Result;
         }
 
         ///<summary>
@@ -130,7 +130,7 @@ namespace SteamTrade
         /// <returns>True if authentication is successful, false otherwise.</returns>
         public bool Authenticate(string myUniqueId, SteamClient client, string myLoginKey)
         {
-            Task<bool> authTask = AuthenticateAsync(myUniqueId, client, myLoginKey);
+            Task<bool> authTask = Task.Run(async() => { return await AuthenticateAsync(myUniqueId, client, myLoginKey); });
             return authTask.Result;
         }
 
@@ -153,7 +153,7 @@ namespace SteamTrade
         /// <returns>True if cookies are valid, false otherwise</returns>
         public bool VerifyCookies()
         {
-            Task<bool> verifyTask = VerifyCookiesAsync();
+            Task<bool> verifyTask = Task.Run(async() => { return await VerifyCookiesAsync(); });
             return verifyTask.Result;
         }
 

--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -59,7 +59,6 @@ namespace SteamTrade
         public HttpWebResponse Request(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
             Task<WebResponse> responseTask = RequestAsync(url, method, data, ajax, referer);
-            responseTask.Wait();
             return responseTask.Result as HttpWebResponse;
         }
 
@@ -77,7 +76,6 @@ namespace SteamTrade
         public string Fetch(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
             Task<string> responseTask = FetchAsync(url, method, data, ajax, referer);
-            responseTask.Wait();
             return responseTask.Result;
         }
 
@@ -133,7 +131,6 @@ namespace SteamTrade
         public bool Authenticate(string myUniqueId, SteamClient client, string myLoginKey)
         {
             Task<bool> authTask = AuthenticateAsync(myUniqueId, client, myLoginKey);
-            authTask.Wait();
             return authTask.Result;
         }
 
@@ -157,7 +154,6 @@ namespace SteamTrade
         public bool VerifyCookies()
         {
             Task<bool> verifyTask = VerifyCookiesAsync();
-            verifyTask.Wait();
             return verifyTask.Result;
         }
 

--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -1,336 +1,169 @@
 using System;
-using System.IO;
 using System.Collections.Specialized;
+using System.IO;
 using System.Net;
 using System.Net.Cache;
-using System.Text;
-using System.Web;
-using System.Security.Cryptography;
-using Newtonsoft.Json;
-using System.Security.Cryptography.X509Certificates;
 using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web;
 using SteamKit2;
 
 namespace SteamTrade
 {
-    public class SteamWeb
+    public sealed class SteamWeb
     {
         public const string SteamCommunityDomain = "steamcommunity.com";
+
+        private CookieContainer cookies = new CookieContainer();
+
         public string Token { get; private set; }
         public string SessionId { get; private set; }
         public string TokenSecure { get; private set; }
-        private CookieContainer _cookies = new CookieContainer();
 
-        public string Fetch(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "")
+        public Task<WebResponse> RequestAsync(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
-            using (HttpWebResponse response = Request(url, method, data, ajax, referer))
-            {
-                using (Stream responseStream = response.GetResponseStream())
-                {
-                    using (StreamReader reader = new StreamReader(responseStream))
-                    {
-                        return reader.ReadToEnd();
-                    }
-                }
-            }
-        }
-
-        public HttpWebResponse Request(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "")
-        {
-            //Append the data to the URL for GET-requests
-            bool isGetMethod = (method.ToLower() == "get");
-            string dataString = (data == null ? null : String.Join("&", Array.ConvertAll(data.AllKeys, key =>
-                String.Format("{0}={1}", HttpUtility.UrlEncode(key), HttpUtility.UrlEncode(data[key]))
-            )));
-
-            if (isGetMethod && !String.IsNullOrEmpty(dataString))
-            {
-                url += (url.Contains("?") ? "&" : "?") + dataString;
-            }
-
-            //Setup the request
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create(url);
-            request.Method = method;
+            bool isGet = method.ToUpper() == "GET";
+            string dString = data == null ? null : string.Join("&", Array.ConvertAll(data.AllKeys, key =>
+                string.Format("{0}={1}", HttpUtility.UrlEncode(key), HttpUtility.UrlEncode(data[key]))
+            ));
+            if (isGet && !string.IsNullOrWhiteSpace(dString))
+                url += (url.Contains("?") ? "&" : "?") + dString;
+            HttpWebRequest request = WebRequest.CreateHttp(url);
             request.Accept = "application/json, text/javascript;q=0.9, */*;q=0.5";
-            request.ContentType = "application/x-www-form-urlencoded; charset=UTF-8";
-            //request.Host is set automatically
-            request.UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36";
-            request.Referer = string.IsNullOrEmpty(referer) ? "http://steamcommunity.com/trade/1" : referer;
-            request.Timeout = 50000; //Timeout after 50 seconds
-            request.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.Revalidate);
+            request.AllowAutoRedirect = true;
             request.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
-
+            request.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.Revalidate);
+            if (!isGet && !string.IsNullOrEmpty(dString))
+            {
+                byte[] dataBytes = Encoding.UTF8.GetBytes(dString);
+                request.ContentLength = dataBytes.Length;
+                using (Stream requestStream = request.GetRequestStream())
+                    requestStream.Write(dataBytes, 0, dataBytes.Length);
+            }
+            request.ContentType = "application/x-www-form-urlencoded; charset=UTF-8";
+            request.CookieContainer = cookies;
             if (ajax)
             {
                 request.Headers.Add("X-Requested-With", "XMLHttpRequest");
                 request.Headers.Add("X-Prototype-Version", "1.7");
             }
-
-            // Cookies
-            request.CookieContainer = _cookies;
-
-            // Write the data to the body for POST and other methods
-            if (!isGetMethod && !String.IsNullOrEmpty(dataString))
-            {
-                byte[] dataBytes = Encoding.UTF8.GetBytes(dataString);
-                request.ContentLength = dataBytes.Length;
-
-                using (Stream requestStream = request.GetRequestStream())
-                {
-                    requestStream.Write(dataBytes, 0, dataBytes.Length);
-                }
-            }
-
-            // Get the response
-            return request.GetResponse() as HttpWebResponse;
+            request.Method = method.ToUpper();
+            request.Referer = referer;
+            request.Timeout = 50000;
+            request.UserAgent = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36";
+            return request.GetResponseAsync();
         }
 
-        /// <summary>
-        /// Executes the login by using the Steam Website.
-        /// </summary>
-        public bool DoLogin(string username, string password)
+        public HttpWebResponse Request(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
-            var data = new NameValueCollection();
-            data.Add("username", username);
-            string response = Fetch("https://steamcommunity.com/login/getrsakey", "POST", data, false);
-            GetRsaKey rsaJSON = JsonConvert.DeserializeObject<GetRsaKey>(response);
+            Task<WebResponse> responseTask = RequestAsync(url, method, data, ajax, referer);
+            responseTask.Wait();
+            return responseTask.Result as HttpWebResponse;
+        }
 
-
-            // Validate
-            if (!rsaJSON.success)
-            {
-                return false;
-            }
-
-            //RSA Encryption
-            RSACryptoServiceProvider rsa = new RSACryptoServiceProvider();
-            RSAParameters rsaParameters = new RSAParameters();
-
-            rsaParameters.Exponent = HexToByte(rsaJSON.publickey_exp);
-            rsaParameters.Modulus = HexToByte(rsaJSON.publickey_mod);
-
-            rsa.ImportParameters(rsaParameters);
-
-            byte[] bytePassword = Encoding.ASCII.GetBytes(password);
-            byte[] encodedPassword = rsa.Encrypt(bytePassword, false);
-            string encryptedBase64Password = Convert.ToBase64String(encodedPassword);
-
-
-            SteamResult loginJson = null;
-            CookieCollection cookieCollection;
-            string steamGuardText = "";
-            string steamGuardId = "";
-            do
-            {
-                Console.WriteLine("SteamWeb: Logging In...");
-
-                bool captcha = loginJson != null && loginJson.captcha_needed == true;
-                bool steamGuard = loginJson != null && loginJson.emailauth_needed == true;
-
-                string time = Uri.EscapeDataString(rsaJSON.timestamp);
-                string capGID = loginJson == null ? null : Uri.EscapeDataString(loginJson.captcha_gid);
-
-                data = new NameValueCollection();
-                data.Add("password", encryptedBase64Password);
-                data.Add("username", username);
-
-                // Captcha
-                string capText = "";
-                if (captcha)
+        public Task<string> FetchAsync(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
+        {
+            return RequestAsync(url, method, data, ajax, referer).ContinueWith(x => {
+                using (WebResponse response = x.Result)
                 {
-                    Console.WriteLine("SteamWeb: Captcha is needed.");
-                    System.Diagnostics.Process.Start("https://steamcommunity.com/public/captcha.php?gid=" + loginJson.captcha_gid);
-                    Console.WriteLine("SteamWeb: Type the captcha:");
-                    capText = Uri.EscapeDataString(Console.ReadLine());
+                    using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                        return reader.ReadToEnd();
                 }
+            });
+        }
 
-                data.Add("captchagid", captcha ? capGID : "");
-                data.Add("captcha_text", captcha ? capText : "");
-                // Captcha end
-
-                // SteamGuard
-                if (steamGuard)
-                {
-                    Console.WriteLine("SteamWeb: SteamGuard is needed.");
-                    Console.WriteLine("SteamWeb: Type the code:");
-                    steamGuardText = Uri.EscapeDataString(Console.ReadLine());
-                    steamGuardId = loginJson.emailsteamid;
-                }
-
-                data.Add("emailauth", steamGuardText);
-                data.Add("emailsteamid", steamGuardId);
-                // SteamGuard end
-
-                data.Add("rsatimestamp", time);
-
-                using(HttpWebResponse webResponse = Request("https://steamcommunity.com/login/dologin/", "POST", data, false))
-                {
-                    using(StreamReader reader = new StreamReader(webResponse.GetResponseStream()))
-                    {
-                        string json = reader.ReadToEnd();
-                        loginJson = JsonConvert.DeserializeObject<SteamResult>(json);
-                        cookieCollection = webResponse.Cookies;
-                    }
-                }
-            } while (loginJson.captcha_needed || loginJson.emailauth_needed);
-
-
-            if (loginJson.success)
-            {
-                _cookies = new CookieContainer();
-                foreach (Cookie cookie in cookieCollection)
-                {
-                    _cookies.Add(cookie);
-                }
-                SubmitCookies(_cookies);
-                return true;
-            }
-            else
-            {
-                Console.WriteLine("SteamWeb Error: " + loginJson.message);
-                return false;
-            }
-
+        public string Fetch(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
+        {
+            Task<string> responseTask = FetchAsync(url, method, data, ajax, referer);
+            responseTask.Wait();
+            return responseTask.Result;
         }
 
         ///<summary>
-        /// Authenticate using SteamKit2 and ISteamUserAuth. 
-        /// This does the same as SteamWeb.DoLogin(), but without contacting the Steam Website.
-        /// </summary> 
-        /// <remarks>Should this one doesnt work anymore, use <see cref="SteamWeb.DoLogin"/></remarks>
-        public bool Authenticate(string myUniqueId, SteamClient client, string myLoginKey)
+        /// Authenticate using SteamKit2 and ISteamUserAuth.
+        /// </summary>
+        /// <returns>True if authentication is successful, false otherwise.</returns>
+        public Task<bool> AuthenticateAsync(string myUniqueId, SteamClient client, string myLoginKey)
         {
             Token = TokenSecure = "";
             SessionId = Convert.ToBase64String(Encoding.UTF8.GetBytes(myUniqueId));
-            _cookies = new CookieContainer();
-
-            using (dynamic userAuth = WebAPI.GetInterface("ISteamUserAuth"))
+            cookies = new CookieContainer();
+            using (dynamic userAuth = WebAPI.GetAsyncInterface("ISteamUserAuth"))
             {
-                // generate an AES session key
                 var sessionKey = CryptoHelper.GenerateRandomBlock(32);
-
-                // rsa encrypt it with the public key for the universe we're on
-                byte[] cryptedSessionKey = null;
+                byte[] cryptedSessionKey = null, loginKey = new byte[20];
                 using (RSACrypto rsa = new RSACrypto(KeyDictionary.GetPublicKey(client.ConnectedUniverse)))
-                {
                     cryptedSessionKey = rsa.Encrypt(sessionKey);
-                }
-
-                byte[] loginKey = new byte[20];
                 Array.Copy(Encoding.ASCII.GetBytes(myLoginKey), loginKey, myLoginKey.Length);
-
-                // aes encrypt the loginkey with our session key
                 byte[] cryptedLoginKey = CryptoHelper.SymmetricEncrypt(loginKey, sessionKey);
-
-                KeyValue authResult;
-
                 try
                 {
-                    authResult = userAuth.AuthenticateUser(
+                    Task<KeyValue> authResult = userAuth.AuthenticateUser(
                         steamid: client.SteamID.ConvertToUInt64(),
                         sessionkey: HttpUtility.UrlEncode(cryptedSessionKey),
                         encrypted_loginkey: HttpUtility.UrlEncode(cryptedLoginKey),
                         method: "POST",
                         secure: true
                         );
+                    return authResult.ContinueWith(x =>
+                    {
+                        KeyValue result = x.Result;
+                        Token = result["token"].AsString();
+                        TokenSecure = result["tokensecure"].AsString();
+                        cookies.Add(new Cookie("sessionid", SessionId, String.Empty, SteamCommunityDomain));
+                        cookies.Add(new Cookie("steamLogin", Token, String.Empty, SteamCommunityDomain));
+                        cookies.Add(new Cookie("steamLoginSecure", TokenSecure, String.Empty, SteamCommunityDomain));
+                        return true;
+                    });
                 }
                 catch (Exception)
                 {
                     Token = TokenSecure = null;
-                    return false;
+                    return Task.Factory.StartNew(delegate () { return false; });
                 }
-
-                Token = authResult["token"].AsString();
-                TokenSecure = authResult["tokensecure"].AsString();
-
-                _cookies.Add(new Cookie("sessionid", SessionId, String.Empty, SteamCommunityDomain));
-                _cookies.Add(new Cookie("steamLogin", Token, String.Empty, SteamCommunityDomain));
-                _cookies.Add(new Cookie("steamLoginSecure", TokenSecure, String.Empty, SteamCommunityDomain));
-
-                return true;
             }
+        }
+
+        ///<summary>
+        /// Authenticate using SteamKit2 and ISteamUserAuth.
+        /// </summary>
+        /// <returns>True if authentication is successful, false otherwise.</returns>
+        public bool Authenticate(string myUniqueId, SteamClient client, string myLoginKey)
+        {
+            Task<bool> authTask = AuthenticateAsync(myUniqueId, client, myLoginKey);
+            authTask.Wait();
+            return authTask.Result;
         }
 
         /// <summary>
-        /// Helper method to verify our precious cookies.
+        /// Are the current cookies valid?
         /// </summary>
-        /// <param name="cookies">CookieContainer with our cookies.</param>
-        /// <returns>true if cookies are correct; false otherwise</returns>
+        /// <returns>True if cookies are valid, false otherwise</returns>
+        public Task<bool> VerifyCookiesAsync()
+        {
+            return RequestAsync("http://" + SteamCommunityDomain, "HEAD").ContinueWith(x =>
+            {
+                using (HttpWebResponse response = x.Result as HttpWebResponse)
+                    return response.Cookies["steamLogin"] == null || !response.Cookies["steamLogin"].Value.Equals("deleted");
+            });
+        }
+
+        /// <summary>
+        /// Are the current cookies valid?
+        /// </summary>
+        /// <returns>True if cookies are valid, false otherwise</returns>
         public bool VerifyCookies()
         {
-            using (HttpWebResponse response = Request("http://steamcommunity.com/", "HEAD"))
-            {
-                return response.Cookies["steamLogin"] == null || !response.Cookies["steamLogin"].Value.Equals("deleted");
-            }
+            Task<bool> verifyTask = VerifyCookiesAsync();
+            verifyTask.Wait();
+            return verifyTask.Result;
         }
 
-        static void SubmitCookies (CookieContainer cookies)
+        public bool ValidateRemoteCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            HttpWebRequest w = WebRequest.Create("https://steamcommunity.com/") as HttpWebRequest;
-
-            w.Method = "POST";
-            w.ContentType = "application/x-www-form-urlencoded";
-            w.CookieContainer = cookies;
-
-            w.GetResponse().Close();
-        }
-
-        private byte[] HexToByte(string hex)
-        {
-            if (hex.Length % 2 == 1)
-                throw new Exception("The binary key cannot have an odd number of digits");
-
-            byte[] arr = new byte[hex.Length >> 1];
-            int l = hex.Length;
-
-            for (int i = 0; i < (l >> 1); ++i)
-            {
-                arr[i] = (byte)((GetHexVal(hex[i << 1]) << 4) + (GetHexVal(hex[(i << 1) + 1])));
-            }
-
-            return arr;
-        }
-
-        private int GetHexVal(char hex)
-        {
-            int val = (int)hex;
-            return val - (val < 58 ? 48 : 55);
-        }
-
-        public bool ValidateRemoteCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors policyErrors)
-        {
-            // allow all certificates
             return true;
         }
-
     }
-
-    // JSON Classes
-    public class GetRsaKey
-    {
-        public bool success { get; set; }
-
-        public string publickey_mod { get; set; }
-
-        public string publickey_exp { get; set; }
-
-        public string timestamp { get; set; }
-    }
-
-    public class SteamResult
-    {
-        public bool success { get; set; }
-
-        public string message { get; set; }
-
-        public bool captcha_needed { get; set; }
-
-        public string captcha_gid { get; set; }
-
-        public bool emailauth_needed { get; set; }
-
-        public string emailsteamid { get; set; }
-
-    }
-
 }

--- a/SteamTrade/SteamWeb.cs
+++ b/SteamTrade/SteamWeb.cs
@@ -75,7 +75,7 @@ namespace SteamTrade
 
         public string Fetch(string url, string method, NameValueCollection data = null, bool ajax = true, string referer = "http://" + SteamCommunityDomain + "/trade/1")
         {
-            Task<string> fetchTask = Task.Run(async() => { return await FetchAsync(url, method, data, ajax, referer)});
+            Task<string> fetchTask = Task.Run(async() => { return await FetchAsync(url, method, data, ajax, referer); });
             return fetchTask.Result;
         }
 


### PR DESCRIPTION
If we ever do get to adding a new inventory fetching system, we need to have SteamWeb prepared to not cause any thread blocking when fetching more then 1 inventory. This PR achieves that.
Note: There is backward compat thread blocking methods that just Wait() on the threaded equivalent.
Edit: Commit 1 can be ignored.
Edit2: This closes #796 