### PR TITLE
Trade Chat message char limit warning

### DIFF
--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -375,6 +375,17 @@ namespace SteamBot
 
         private void SendTradeMessageImpl(string message)
         {
+            if (message.Length > 100)
+            {
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write("Message '");
+                Console.ForegroundColor = ConsoleColor.DarkMagenta;
+                Console.Write(message);
+                Console.ForegroundColor = ConsoleColor.Yellow;
+                Console.Write("' is longer than 100 characters, the trade message gets trimmed during this process\n");
+                Console.ResetColor();
+            }
+
             if (Trade != null && !Trade.HasTradeEnded)
             {
                 Trade.SendMessage(message);

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -377,7 +377,7 @@ namespace SteamBot
         {
             if (message.Length > 100)
             {
-                Log.Warn("Message '{0}' is longer than 100 characters, the trade message gets trimmed during this process.", message);
+                Log.Warn("'{0}' is longer than 100 chars, it will be trimmed.", message);
             }
 
             if (Trade != null && !Trade.HasTradeEnded)

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -377,13 +377,7 @@ namespace SteamBot
         {
             if (message.Length > 100)
             {
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Write("Message '");
-                Console.ForegroundColor = ConsoleColor.DarkMagenta;
-                Console.Write(message);
-                Console.ForegroundColor = ConsoleColor.Yellow;
-                Console.Write("' is longer than 100 characters, the trade message gets trimmed during this process\n");
-                Console.ResetColor();
+                Log.Warn("Message '{0}' is longer than 100 characters, the trade message gets trimmed during this process.", message);
             }
 
             if (Trade != null && !Trade.HasTradeEnded)


### PR DESCRIPTION
Now the console outputs a colorful warning when the SendTradeMessage
argument exceeds then 100 char limit.