### PR TITLE
Trade email confirmation implementation

### DIFF
--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -11,14 +11,12 @@ namespace SteamBot
         private readonly GenericInventory OtherSteamInventory;
 
         private bool tested;
-        protected SteamWeb SW;
         // ----------------------------------------------------------------------
 
         public SteamTradeDemoHandler(Bot bot, SteamID sid) : base(bot, sid)
         {
             mySteamInventory = new GenericInventory(SteamWeb);
             OtherSteamInventory = new GenericInventory(SteamWeb);
-            SW = SteamWeb;
         }
 
         public override bool OnGroupAdd()
@@ -208,28 +206,6 @@ namespace SteamBot
             CheckIfEmailConfirmationFinished(tradeOfferID, 120, 5); //120 tries, 5 seconds per try, therefore 10 mins by default
         }
 
-        public void CheckIfEmailConfirmationFinished(long tradeOfferID, int triesToGo, float secondsForCheck)
-        {
-            if (triesToGo > 0)
-            {
-                TradeOfferWebAPI tradeOffer = new TradeOfferWebAPI(Bot.ApiKey, SW);
-                TradeOfferState st = tradeOffer.GetOfferState(tradeOfferID.ToString());
-                if (st == TradeOfferState.TradeOfferStateAccepted)
-                {
-                    OnTradeSuccess();
-                    Log.Success("Trade has been made and confirmed by email.");
-                }
-                else if (st == TradeOfferState.TradeOfferStateCanceled)
-                {
-                    SendChatMessage("Trade offer email validation has been declined.");
-                }
-                else
-                {
-                    Action toDo = () => CheckIfEmailConfirmationFinished(tradeOfferID, triesToGo - 1, secondsForCheck);
-                    toDo.DelayFor(TimeSpan.FromSeconds(secondsForCheck));
-                }
-            }
-        }
         
         public override void OnTradeAccept() 
         {
@@ -269,12 +245,4 @@ namespace SteamBot
  
 }
 
-public static class ActionExtensions
-{
-    public static async void DelayFor(this Action act, TimeSpan delay)
-    {
-        await Task.Delay(delay);
-        act();
-    }
-} //for making delayed function calls simple, taken from stackoverflow
 

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -432,7 +432,7 @@ namespace SteamBot
         /// <param name="tradeOfferID">The trade offer to check, usually you'll just want to pass the one from OnTradeAwaitingEmailConfirmation()</param>
         /// <param name="triesToGo">How many times it should be checked before giving up</param>
         /// <param name="secondsForCheck">How frequently the offer state should be checked, in seconds</param>
-        protected virtual void CheckIfEmailConfirmationFinished(long tradeOfferID, int triesToGo, float secondsForCheck)
+        protected async virtual void CheckIfEmailConfirmationFinished(long tradeOfferID, int triesToGo, float secondsForCheck)
         {
             if (triesToGo > 0)
             {
@@ -449,21 +449,12 @@ namespace SteamBot
                 }
                 else
                 {
-                    Action toDo = () => CheckIfEmailConfirmationFinished(tradeOfferID, triesToGo - 1, secondsForCheck);
-                    toDo.DelayFor(TimeSpan.FromSeconds(secondsForCheck));
+                    await Task.Delay(TimeSpan.FromSeconds(secondsForCheck));
+                    CheckIfEmailConfirmationFinished(tradeOfferID, triesToGo - 1, secondsForCheck);
                 }
             }
         }
         #endregion
     }
 }
-
-public static class ActionExtensions
-{
-    public static async void DelayFor(this Action act, TimeSpan delay)
-    {
-        await Task.Delay(delay);
-        act();
-    }
-} //for making delayed function calls simple, taken from stackoverflow
 


### PR DESCRIPTION
So, I've been playing with the project for the last few days, customized it to my own liking so it can work with the CSGO market instead, I'm planning to use it for a jackpot site and I want people to trade in items and add the total value of the items in the trade to their account somewhere in a database.

However, when the user's got email confirmation turned on (which it is by default), things start going downhill. I've checked all I could, but I haven't found an event that actually checks whether the email confirmation has finished, which I crucially need while still holding the trade value inside of my customized class.
At this point, we're unsubscribed from the trade, but the instance of the trade has not been destroyed yet, so we can still work with any other variables inside of the class.

The action extension class at the bottom can probably be implemented in a smarter way, let me know if you have any ideas.