### PR TITLE
Bot/log disposal fix

### DIFF
--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -331,6 +331,7 @@ namespace SteamBot
                 {
                     TheBot.StopBot();
                     IsRunning = false;
+                    TheBot.Dispose();
                 }
             }
 


### PR DESCRIPTION
- Previously, if the bot was forcibly, or even due to an error stopped
and then started again without restarting the entire application, the
program would throw an error while trying to write to the log file,
because it was still open.
- The function for the disposal was already properly defined, but never
called if the GC never picked it up, since it's only called in the destructor (which it did not on my machine).

Basically, this forces the bot manager to dispose of the bot and its log without having to wait for GC to pick it up, which may sometimes take a long time.