### PR TITLE
Added mobile auth support + trade confirmations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "SteamAuth"]
+	path = SteamAuth
+	url = https://github.com/geel9/SteamAuth

--- a/SteamBot.sln
+++ b/SteamBot.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleBot", "SteamBot\ExampleBot.csproj", "{E81DED36-EDF5-41A5-8666-A3A0C581762F}"
 EndProject
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C8129C
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SteamAuth", "SteamAuth\SteamAuth\SteamAuth.csproj", "{5AD0934E-F6C4-4AE5-83AF-C788313B2A87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,6 +30,10 @@ Global
 		{6CEC0333-81EB-40EE-85D1-941363626FC7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CEC0333-81EB-40EE-85D1-941363626FC7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CEC0333-81EB-40EE-85D1-941363626FC7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5AD0934E-F6C4-4AE5-83AF-C788313B2A87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5AD0934E-F6C4-4AE5-83AF-C788313B2A87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5AD0934E-F6C4-4AE5-83AF-C788313B2A87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5AD0934E-F6C4-4AE5-83AF-C788313B2A87}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SteamBot/AdminUserHandler.cs
+++ b/SteamBot/AdminUserHandler.cs
@@ -134,10 +134,10 @@ namespace SteamBot
             Log.Success("Trade Complete.");
         }
 
-        public override void OnTradeAwaitingEmailConfirmation(long tradeOfferID)
+        public override void OnTradeAwaitingConfirmation(long tradeOfferID)
         {
-            Log.Warn("Trade ended awaiting email confirmation");
-            SendChatMessage("Please complete the email confirmation to finish the trade");
+            Log.Warn("Trade ended awaiting confirmation");
+            SendChatMessage("Please complete the confirmation to finish the trade");
         }
 
         public override void OnTradeAccept()

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -45,6 +45,7 @@ namespace SteamBot
         private bool cookiesAreInvalid = true;
         private List<SteamID> friends;
         private bool disposed = false;
+        private string consoleInput;
         #endregion
 
         #region Public readonly variables
@@ -112,6 +113,8 @@ namespace SteamBot
         /// Default: 0 = No game.
         /// </summary>
         public int CurrentGame { get; private set; }
+
+        public SteamAuth.SteamGuardAccount SteamGuardAccount;
         #endregion
 
         public IEnumerable<SteamID> FriendsList
@@ -191,6 +194,13 @@ namespace SteamBot
             ServicePointManager.ServerCertificateValidationCallback += SteamWeb.ValidateRemoteCertificate;
 
             Log.Debug ("Initializing Steam Bot...");
+
+            var mobileAuthCode = GetMobileAuthCode();
+            if (!string.IsNullOrEmpty(mobileAuthCode))
+            {
+                logOnDetails.TwoFactorCode = mobileAuthCode;
+            }
+
             SteamClient = new SteamClient();
             SteamClient.AddHandler(new SteamNotifications());
             SteamTrade = SteamClient.GetHandler<SteamTrading>();
@@ -319,7 +329,25 @@ namespace SteamBot
         {
             try
             {
-                GetUserHandler(SteamClient.SteamID).OnBotCommand(command);
+                if (command == "linkauth")
+                {
+                    LinkMobileAuth();
+                }
+                else if (command == "getauth")
+                {
+                    try
+                    {
+                        Log.Info("Generated Steam Guard code: " + SteamGuardAccount.GenerateSteamGuardCode());
+                    }
+                    catch (NullReferenceException)
+                    {
+                        Log.Info("Unable to generate Steam Guard code.");
+                    }
+                }
+                else
+                {
+                    GetUserHandler(SteamClient.SteamID).OnBotCommand(command);
+                }
             }
             catch (ObjectDisposedException e)
             {
@@ -333,6 +361,24 @@ namespace SteamBot
             catch (Exception e)
             {
                 Console.WriteLine(string.Format("Exception caught in BotCommand Thread: {0}", e));
+            }
+        }
+
+        public void HandleInput(string input)
+        {
+            consoleInput = input;
+        }
+
+        public string WaitForInput()
+        {
+            consoleInput = null;
+            while (true)
+            {
+                if (consoleInput != null)
+                {
+                    return consoleInput;
+                }
+                Thread.Sleep(5);
             }
         }
 
@@ -678,6 +724,98 @@ namespace SteamBot
                 //Log.Info("New Commments Subscriptions" + callback.CommentNotifications.CountNewCommentsSubscriptions);
             });
             #endregion
+        }
+
+        string GetMobileAuthCode()
+        {
+            var authFile = Path.Combine("authfiles", String.Format("{0}.auth", logOnDetails.Username));
+            if (File.Exists(authFile))
+            {
+                SteamGuardAccount = Newtonsoft.Json.JsonConvert.DeserializeObject<SteamAuth.SteamGuardAccount>(File.ReadAllText(authFile));
+                return SteamGuardAccount.GenerateSteamGuardCode();
+            }
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Link a mobile authenticator to bot account, using SteamTradeOffersBot as the authenticator.
+        /// Called from bot manager console. Usage: "exec [index] linkauth"
+        /// If successful, 2FA will be required upon the next login.
+        /// Use "exec [index] getauth" if you need to get a Steam Guard code for the account.
+        /// </summary>
+        void LinkMobileAuth()
+        {
+            new Thread(() =>
+            {
+                var login = new SteamAuth.UserLogin(logOnDetails.Username, logOnDetails.Password);
+                var loginResult = login.DoLogin();
+                if (loginResult == SteamAuth.LoginResult.NeedEmail)
+                {
+                    while (loginResult == SteamAuth.LoginResult.NeedEmail)
+                    {
+                        Log.Interface("Enter Steam Guard code from email (type \"input [index] [code]\"):");
+                        var emailCode = WaitForInput();
+                        login.EmailCode = emailCode;
+                        loginResult = login.DoLogin();
+                    }
+                }
+                if (loginResult == SteamAuth.LoginResult.LoginOkay)
+                {
+                    Log.Info("Linking mobile authenticator...");
+                    var authLinker = new SteamAuth.AuthenticatorLinker(login.Session);
+                    var addAuthResult = authLinker.AddAuthenticator();
+                    if (addAuthResult == SteamAuth.AuthenticatorLinker.LinkResult.MustProvidePhoneNumber)
+                    {
+                        while (addAuthResult == SteamAuth.AuthenticatorLinker.LinkResult.MustProvidePhoneNumber)
+                        {
+                            Log.Interface("Enter phone number with country code, e.g. +1XXXXXXXXXXX (type \"input [index] [number]\"):");
+                            var phoneNumber = WaitForInput();
+                            authLinker.PhoneNumber = phoneNumber;
+                            addAuthResult = authLinker.AddAuthenticator();
+                        }
+                    }
+                    if (addAuthResult == SteamAuth.AuthenticatorLinker.LinkResult.AwaitingFinalization)
+                    {
+                        SteamGuardAccount = authLinker.LinkedAccount;
+                        try
+                        {
+                            var authFile = Path.Combine("authfiles", String.Format("{0}.auth", logOnDetails.Username));
+                            Directory.CreateDirectory(Path.Combine(System.Windows.Forms.Application.StartupPath, "authfiles"));
+                            File.WriteAllText(authFile, Newtonsoft.Json.JsonConvert.SerializeObject(SteamGuardAccount));
+                        }
+                        catch
+                        {
+
+                        }
+                        Log.Interface("Enter SMS code (type \"input [index] [code]\"):");
+                        var smsCode = WaitForInput();
+                        var authResult = authLinker.FinalizeAddAuthenticator(smsCode);
+                        if (authResult == SteamAuth.AuthenticatorLinker.FinalizeResult.Success)
+                        {
+                            Log.Success("Linked authenticator.");
+                        }
+                        else
+                        {
+                            Log.Error("Error linking authenticator: " + authResult);
+                        }
+                    }
+                    else
+                    {
+                        Log.Error("Error adding authenticator: " + addAuthResult);
+                    }
+                }
+                else
+                {
+                    if (loginResult == SteamAuth.LoginResult.Need2FA)
+                    {
+                        Log.Error("Mobile authenticator has already been linked!");
+                    }
+                    else
+                    {
+                        Log.Error("Error performing mobile login: " + loginResult);
+                    }
+                }
+            }).Start();
         }
 
         void UserLogOn()

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -985,7 +985,7 @@ namespace SteamBot
         public void SubscribeTrade (Trade trade, UserHandler handler)
         {
             trade.OnSuccess += handler.OnTradeSuccess;
-            trade.OnAwaitingEmailConfirmation += handler.OnTradeAwaitingEmailConfirmation;
+            trade.OnAwaitingConfirmation += handler._OnTradeAwaitingConfirmation;
             trade.OnClose += handler.OnTradeClose;
             trade.OnError += handler.OnTradeError;
             trade.OnStatusError += handler.OnStatusError;
@@ -1004,7 +1004,7 @@ namespace SteamBot
         public void UnsubscribeTrade (UserHandler handler, Trade trade)
         {
             trade.OnSuccess -= handler.OnTradeSuccess;
-            trade.OnAwaitingEmailConfirmation -= handler.OnTradeAwaitingEmailConfirmation;
+            trade.OnAwaitingConfirmation -= handler._OnTradeAwaitingConfirmation;
             trade.OnClose -= handler.OnTradeClose;
             trade.OnError -= handler.OnTradeError;
             trade.OnStatusError -= handler.OnStatusError;
@@ -1028,6 +1028,33 @@ namespace SteamBot
                 log.Warn("The bot's backpack is private! If your bot adds any items it will fail! Your bot's backpack should be Public.");
             }
             return inventory;
+        }
+
+        public void AcceptAllMobileTradeConfirmations()
+        {
+            if (SteamGuardAccount == null)
+            {
+                Log.Warn("Bot account does not have 2FA enabled.");
+            }
+            else
+            {
+                SteamGuardAccount.Session.SteamLogin = SteamWeb.Token;
+                SteamGuardAccount.Session.SteamLoginSecure = SteamWeb.TokenSecure;
+                try
+                {
+                    foreach (var confirmation in SteamGuardAccount.FetchConfirmations())
+                    {
+                        if (SteamGuardAccount.AcceptConfirmation(confirmation))
+                        {
+                            Log.Success("Confirmed {0}. (Confirmation ID #{1})", confirmation.ConfirmationDescription, confirmation.ConfirmationID);
+                        }
+                    }
+                }
+                catch (SteamAuth.SteamGuardAccount.WGTokenInvalidException)
+                {
+                    Log.Error("Invalid session when trying to fetch trade confirmations.");
+                }
+            }                        
         }
 
         #region Background Worker Methods

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -341,7 +341,18 @@ namespace SteamBot
                     }
                     catch (NullReferenceException)
                     {
-                        Log.Info("Unable to generate Steam Guard code.");
+                        Log.Error("Unable to generate Steam Guard code.");
+                    }
+                }
+                else if (command == "unlinkauth")
+                {
+                    if (SteamGuardAccount.DeactivateAuthenticator())
+                    {
+                        Log.Success("Deactivated authenticator on this account.");
+                    }
+                    else
+                    {
+                        Log.Error("Failed to deactivate authenticator on this account.");
                     }
                 }
                 else
@@ -742,6 +753,7 @@ namespace SteamBot
         /// Called from bot manager console. Usage: "exec [index] linkauth"
         /// If successful, 2FA will be required upon the next login.
         /// Use "exec [index] getauth" if you need to get a Steam Guard code for the account.
+        /// To deactivate the authenticator, use "exec [index] unlinkauth".
         /// </summary>
         void LinkMobileAuth()
         {

--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -234,6 +234,42 @@ namespace SteamBot
         }
 
         /// <summary>
+        /// Sends the BotManager input to the target Bot
+        /// </summary>
+        /// <param name="index">The target bot's index</param>
+        /// <param name="command">The input to give the bot</param>
+        public void SendInput(int index, string input)
+        {
+            mainLog.Debug(String.Format("Sending input \"{0}\" to Bot at index {1}", input, index));
+            if (index < botProcs.Count)
+            {
+                if (botProcs[index].IsRunning)
+                {
+                    if (botProcs[index].UsingProcesses)
+                    {
+                        //  Write out the exec command to the bot process' stdin
+                        StreamWriter BotStdIn = botProcs[index].BotProcess.StandardInput;
+
+                        BotStdIn.WriteLine("input " + input);
+                        BotStdIn.Flush();
+                    }
+                    else
+                    {
+                        botProcs[index].TheBot.HandleInput(input);
+                    }
+                }
+                else
+                {
+                    mainLog.Warn(String.Format("Bot at index {0} is not running. Use the 'Start' command first", index));
+                }
+            }
+            else
+            {
+                mainLog.Warn(String.Format("Invalid Bot index: {0}", index));
+            }
+        }
+
+        /// <summary>
         /// A method to return an instance of the <c>bot.BotControlClass</c>.
         /// </summary>
         /// <param name="bot">The bot.</param>

--- a/SteamBot/BotManagerInterpreter.cs
+++ b/SteamBot/BotManagerInterpreter.cs
@@ -39,7 +39,10 @@ namespace SteamBot
                                              AuthSet),
                         new BotManagerOption("exec", 
                                              "exec (X) (Y) where X = the username or index of the bot and Y = your custom command to execute",
-                                             ExecCommand)
+                                             ExecCommand),
+                        new BotManagerOption("input",
+                                             "input (X) (Y) where X = the username or index of the bot and Y = your input",
+                                             InputCommand)
                     };
         }
 
@@ -190,6 +193,46 @@ namespace SteamBot
                     if (manager.ConfigObject.Bots[index].Username.Equals(cs[0], StringComparison.CurrentCultureIgnoreCase))
                     {
                         manager.SendCommand(index, command);
+                        return;
+                    }
+                }
+            }
+            // Print error
+            Console.WriteLine("Error: Bot " + cs[0] + " not found.");
+        }
+
+        private void InputCommand(string inpt)
+        {
+            inpt = inpt.Trim();
+
+            var cs = inpt.Split(' ');
+
+            if (cs.Length < 2)
+            {
+                Console.WriteLine("Error: No input given.");
+                return;
+            }
+
+            // Take the rest of the input as is
+            var input = inpt.Remove(0, cs[0].Length + 1);
+
+            int index;
+            // Try index first then search usernames
+            if (int.TryParse(cs[0], out index) && (index < manager.ConfigObject.Bots.Length))
+            {
+                if (manager.ConfigObject.Bots.Length > index)
+                {
+                    manager.SendInput(index, input);
+                    return;
+                }
+            }
+            else if (!String.IsNullOrEmpty(cs[0]))
+            {
+                for (index = 0; index < manager.ConfigObject.Bots.Length; index++)
+                {
+                    if (manager.ConfigObject.Bots[index].Username.Equals(cs[0], StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        manager.SendInput(index, input);
                         return;
                     }
                 }

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>SteamBot</AssemblyName>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -92,6 +92,10 @@
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
+    <ProjectReference Include="..\SteamAuth\SteamAuth\SteamAuth.csproj">
+      <Project>{5ad0934e-f6c4-4ae5-83af-c788313b2a87}</Project>
+      <Name>SteamAuth</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SteamTrade\SteamTrade.csproj">
       <Project>{6CEC0333-81EB-40EE-85D1-941363626FC7}</Project>
       <Name>SteamTrade</Name>

--- a/SteamBot/Program.cs
+++ b/SteamBot/Program.cs
@@ -80,6 +80,7 @@ namespace SteamBot
 
             string AuthSet = "auth";
             string ExecCommand = "exec";
+            string InputCommand = "input";
 
             // this loop is needed to keep the botmode console alive.
             // instead of just sleeping, this loop will handle console input
@@ -104,6 +105,10 @@ namespace SteamBot
                     else if (cs[0].Equals(ExecCommand, StringComparison.CurrentCultureIgnoreCase))
                     {
                         b.HandleBotCommand(c.Remove(0, cs[0].Length + 1));
+                    }
+                    else if (cs[0].Equals(InputCommand, StringComparison.CurrentCultureIgnoreCase))
+                    {
+                        b.HandleInput(c.Remove(0, cs[0].Length + 1));
                     }
                 }
             }

--- a/SteamBot/SimpleUserHandler.cs
+++ b/SteamBot/SimpleUserHandler.cs
@@ -87,10 +87,10 @@ namespace SteamBot
             Log.Success("Trade Complete.");
         }
 
-        public override void OnTradeAwaitingEmailConfirmation(long tradeOfferID)
+        public override void OnTradeAwaitingConfirmation(long tradeOfferID)
         {
-            Log.Warn("Trade ended awaiting email confirmation");
-            SendChatMessage("Please complete the email confirmation to finish the trade");
+            Log.Warn("Trade ended awaiting confirmation");
+            SendChatMessage("Please complete the confirmation to finish the trade");
         }
 
         public override void OnTradeAccept() 

--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -199,10 +199,10 @@ namespace SteamBot
             Log.Success("Trade Complete.");
         }
 
-        public override void OnTradeAwaitingEmailConfirmation(long tradeOfferID)
+        public override void OnTradeAwaitingConfirmation(long tradeOfferID)
         {
-            Log.Warn("Trade ended awaiting email confirmation");
-            SendChatMessage("Please complete the email confirmation to finish the trade");
+            Log.Warn("Trade ended awaiting confirmation");
+            SendChatMessage("Please complete the confirmation to finish the trade");
         }
 
         public override void OnTradeAccept() 

--- a/SteamBot/TradeOfferUserHandler.cs
+++ b/SteamBot/TradeOfferUserHandler.cs
@@ -32,6 +32,7 @@ namespace SteamBot
                     string tradeid;
                     if (offer.Accept(out tradeid))
                     {
+                        Bot.AcceptAllMobileTradeConfirmations();
                         Log.Success("Accepted trade offer successfully : Trade ID: " + tradeid);
                     }
                 }
@@ -46,6 +47,7 @@ namespace SteamBot
                         string newOfferId;
                         if (offer.CounterOffer(out newOfferId))
                         {
+                            Bot.AcceptAllMobileTradeConfirmations();
                             Log.Success("Counter offered successfully : New Offer ID: " + newOfferId);
                         }
                     }
@@ -74,6 +76,7 @@ namespace SteamBot
                     string newOfferId;
                     if (offer.Send(out newOfferId))
                     {
+                        Bot.AcceptAllMobileTradeConfirmations();
                         Log.Success("Trade offer sent : Offer ID " + newOfferId);
                     }
                 }
@@ -88,6 +91,7 @@ namespace SteamBot
                     // "token" should be replaced with the actual token from the other user
                     if (offerWithToken.SendWithToken(out newOfferId, "token"))
                     {
+                        Bot.AcceptAllMobileTradeConfirmations();
                         Log.Success("Trade offer sent : Offer ID " + newOfferId);
                     }
                 }
@@ -110,7 +114,7 @@ namespace SteamBot
 
         public override void OnTradeSuccess() { }
 
-        public override void OnTradeAwaitingEmailConfirmation(long tradeOfferID) { }
+        public override void OnTradeAwaitingConfirmation(long tradeOfferID) { }
 
         public override void OnTradeInit() { }
 

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -246,7 +246,7 @@ namespace SteamBot
             TradeOffer tradeOffer;
             if (Bot.TryGetTradeOffer(tradeOfferID.ToString(), out tradeOffer))
             {
-                if (tradeOffer.OfferState == TradeOfferState.TradeOfferStateAwaitingEmailConfirmation)
+                if (tradeOffer.OfferState == TradeOfferState.TradeOfferStateNeedsConfirmation)
                 {
                     OnTradeAwaitingConfirmation(tradeOfferID);
                 }

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -240,7 +240,19 @@ namespace SteamBot
 
         public abstract void OnTradeSuccess ();
 
-        public abstract void OnTradeAwaitingEmailConfirmation (long tradeOfferID);
+        public void _OnTradeAwaitingConfirmation(long tradeOfferID)
+        {
+            Bot.AcceptAllMobileTradeConfirmations();
+            TradeOffer tradeOffer;
+            if (Bot.TryGetTradeOffer(tradeOfferID.ToString(), out tradeOffer))
+            {
+                if (tradeOffer.OfferState == TradeOfferState.TradeOfferStateAwaitingEmailConfirmation)
+                {
+                    OnTradeAwaitingConfirmation(tradeOfferID);
+                }
+            }            
+        }
+        public abstract void OnTradeAwaitingConfirmation(long tradeOfferID);
 
         public virtual void OnTradeClose ()
         {

--- a/SteamBot/app.config
+++ b/SteamBot/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup></configuration>

--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -28,7 +28,7 @@ namespace SteamTrade
             TradeCancelled = 3,
             SessionExpired = 4,
             TradeFailed = 5,
-            PendingEmail = 6
+            PendingConfirmation = 6
         }
 
         public string GetTradeStatusErrorString(TradeStatusType tradeStatusType)
@@ -47,7 +47,7 @@ namespace SteamTrade
                     return String.Format("expired because {0} timed out", (otherUserTimingOut ? "other user" : "bot"));
                 case TradeStatusType.TradeFailed:
                     return "failed unexpectedly";
-                case TradeStatusType.PendingEmail:
+                case TradeStatusType.PendingConfirmation:
                     return "completed - pending e-mail confirmation";
                 default:
                     return "STATUS IS UNKNOWN - THIS SHOULD NEVER HAPPEN!";
@@ -196,14 +196,14 @@ namespace SteamTrade
         /// Gets a value indicating whether the trade completed awaiting email confirmation. This
         /// is independent of other flags.
         /// </summary>
-        public bool IsTradeAwaitingEmailConfirmation { get; private set; }
+        public bool IsTradeAwaitingConfirmation { get; private set; }
 
         /// <summary>
         /// Gets a value indicating whether the trade has finished (regardless of the cause, eg. success, cancellation, error, etc)
         /// </summary>
         public bool HasTradeEnded
         {
-            get { return OtherUserCancelled || HasTradeCompletedOk || IsTradeAwaitingEmailConfirmation || tradeCancelledByBot; }
+            get { return OtherUserCancelled || HasTradeCompletedOk || IsTradeAwaitingConfirmation || tradeCancelledByBot; }
         }
 
         /// <summary>
@@ -254,7 +254,7 @@ namespace SteamTrade
         /// <summary>
         /// Called when the trade ends awaiting email confirmation
         /// </summary>
-        public event WaitingForEmailHandler OnAwaitingEmailConfirmation;
+        public event WaitingForEmailHandler OnAwaitingConfirmation;
 
         /// <summary>
         /// This is for handling errors that may occur, like inventories
@@ -601,9 +601,9 @@ namespace SteamTrade
                     HasTradeCompletedOk = true;
                     return false;
 
-                // Email confirmation
-                case TradeStatusType.PendingEmail:
-                    IsTradeAwaitingEmailConfirmation = true;
+                // Email/mobile confirmation
+                case TradeStatusType.PendingConfirmation:
+                    IsTradeAwaitingConfirmation = true;
                     tradeOfferID = long.Parse(status.tradeid);
                     return false;
 
@@ -858,12 +858,12 @@ namespace SteamTrade
                 onSuccessEvent();
         }
 
-        internal void FireOnAwaitingEmailConfirmation()
+        internal void FireOnAwaitingConfirmation()
         {
-            var onAwaitingEmailConfirmation = OnAwaitingEmailConfirmation;
+            var onAwaitingConfirmation = OnAwaitingConfirmation;
 
-            if (onAwaitingEmailConfirmation != null)
-                onAwaitingEmailConfirmation(tradeOfferID);
+            if (onAwaitingConfirmation != null)
+                onAwaitingConfirmation(tradeOfferID);
         }
 
         internal void FireOnCloseEvent()

--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -48,7 +48,7 @@ namespace SteamTrade
                 case TradeStatusType.TradeFailed:
                     return "failed unexpectedly";
                 case TradeStatusType.PendingConfirmation:
-                    return "completed - pending e-mail confirmation";
+                    return "completed - pending confirmation";
                 default:
                     return "STATUS IS UNKNOWN - THIS SHOULD NEVER HAPPEN!";
             }

--- a/SteamTrade/TradeManager.cs
+++ b/SteamTrade/TradeManager.cs
@@ -295,8 +295,8 @@ namespace SteamTrade
                         {
                             if(trade.HasTradeCompletedOk)
                                 trade.FireOnSuccessEvent();
-                            else if(trade.IsTradeAwaitingEmailConfirmation)
-                                trade.FireOnAwaitingEmailConfirmation();
+                            else if(trade.IsTradeAwaitingConfirmation)
+                                trade.FireOnAwaitingConfirmation();
                         }
                         finally
                         {

--- a/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
+++ b/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
@@ -240,6 +240,16 @@ namespace SteamTrade.TradeOffer
 
         [JsonProperty("time_updated")]
         public int TimeUpdated { get; set; }
+
+        [JsonProperty("from_real_time_trade")]
+        public bool FromRealTimeTrade { get; set; }
+
+        [JsonProperty("escrow_end_date")]
+        public int EscrowEndDate { get; set; }
+
+        [JsonProperty("confirmation_method")]
+        private int confirmationMethod { get; set; }
+        public TradeOfferConfirmationMethod ConfirmationMethod { get { return (TradeOfferConfirmationMethod)confirmationMethod; } set { confirmationMethod = (int)value; } }
     }
 
     public enum TradeOfferState
@@ -252,9 +262,17 @@ namespace SteamTrade.TradeOffer
         TradeOfferStateCanceled = 6,
         TradeOfferStateDeclined = 7,
         TradeOfferStateInvalidItems = 8,
-        TradeOfferStateAwaitingEmailConfirmation = 9,
-        TradeOfferStateEmailConfirmationCancelled = 10,
+        TradeOfferStateNeedsConfirmation = 9,
+        TradeOfferStateCanceledBySecondFactor = 10,
+        TradeOfferStateInEscrow = 11,
         TradeOfferStateUnknown
+    }
+
+    public enum TradeOfferConfirmationMethod
+    {
+        TradeOfferConfirmationMethodInvalid = 0,
+        TradeOfferConfirmationMethodEmail = 1,
+        TradeOfferConfirmationMethodMobileApp = 2
     }
 
     public class CEconAsset


### PR DESCRIPTION
Features:
* mobile auth support
* trade offer confirmations
* live trade confirmations

AppVeyor will likely fail to build this after merging. Needs some pre-build commands added in "/settings/build" URL:
* Set "Visual Studio solution or project file" to `SteamBot.sln`
* In "Before build script", add
    `git submodule update --init --recursive` and `nuget restore SteamAuth\SteamAuth\SteamAuth.sln`

Have a look and feel free to test (confirmed working on my [SteamTradeOffersBot](https://github.com/waylaidwanderer/SteamTradeOffersBot/) fork).