### PR TITLE
Improvments/fixes to mobile auth

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -330,7 +330,7 @@ namespace SteamBot
                 {
                     try
                     {
-                        Log.Info("Generated Steam Guard code: " + SteamGuardAccount.GenerateSteamGuardCode());
+                        Log.Success("Generated Steam Guard code: " + SteamGuardAccount.GenerateSteamGuardCode());
                     }
                     catch (NullReferenceException)
                     {

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -339,7 +339,11 @@ namespace SteamBot
                 }
                 else if (command == "unlinkauth")
                 {
-                    if (SteamGuardAccount.DeactivateAuthenticator())
+                    if (SteamGuardAccount == null)
+                    {
+                        Log.Error("Mobile authenticator is not active on this bot.");
+                    }
+                    else if (SteamGuardAccount.DeactivateAuthenticator())
                     {
                         Log.Success("Deactivated authenticator on this account.");
                     }

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -488,6 +488,7 @@ namespace SteamBot
                 }
                 else if (callback.Result == EResult.TwoFactorCodeMismatch)
                 {
+                    SteamAuth.TimeAligner.AlignTime();
                     logOnDetails.TwoFactorCode = SteamGuardAccount.GenerateSteamGuardCode();
                     Log.Success("Regenerated 2FA code.");
                 }

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -809,22 +809,22 @@ namespace SteamBot
                             var authFile = Path.Combine("authfiles", String.Format("{0}.auth", logOnDetails.Username));
                             Directory.CreateDirectory(Path.Combine(System.Windows.Forms.Application.StartupPath, "authfiles"));
                             File.WriteAllText(authFile, Newtonsoft.Json.JsonConvert.SerializeObject(SteamGuardAccount));
+                            Log.Interface("Enter SMS code (type \"input [index] [code]\"):");
+                            var smsCode = WaitForInput();
+                            var authResult = authLinker.FinalizeAddAuthenticator(smsCode);
+                            if (authResult == SteamAuth.AuthenticatorLinker.FinalizeResult.Success)
+                            {
+                                Log.Success("Linked authenticator.");
+                            }
+                            else
+                            {
+                                Log.Error("Error linking authenticator: " + authResult);
+                            }
                         }
-                        catch
+                        catch (IOException)
                         {
-
-                        }
-                        Log.Interface("Enter SMS code (type \"input [index] [code]\"):");
-                        var smsCode = WaitForInput();
-                        var authResult = authLinker.FinalizeAddAuthenticator(smsCode);
-                        if (authResult == SteamAuth.AuthenticatorLinker.FinalizeResult.Success)
-                        {
-                            Log.Success("Linked authenticator.");
-                        }
-                        else
-                        {
-                            Log.Error("Error linking authenticator: " + authResult);
-                        }
+                            Log.Error("Failed to save auth file. Aborting authentication.");
+                        }                        
                     }
                     else
                     {


### PR DESCRIPTION
Features
* `SteamGuardAccount` is only instantiated by calling `GetMobileAuthCode()` when `EResult.AccountLogonDeniedNeedTwoFactorCode` is encountered, to prevent a case where if you delink the authenticator but don't delete the auth file, it will still generate the 2FA code causing a `EResult.InvalidPassword` error.
* Regenerates 2FA code upon `EResult.TwoFactorCodeMismatch` (the error happens occasionally and this seems to fix it)
* Checks if `SteamGuardAccount` is null before calling `DeactivateAuthenticator()`