### PR TITLE
Added check if mainLog is null in BotManager.cs

### DIFF
--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -99,13 +99,16 @@ namespace SteamBot
         /// </summary>
         public void StopBots()
         {
-            mainLog.Debug("Shutting down all bot processes.");
-            foreach (var botProc in botProcs)
+            if (mainLog != null)
             {
-                botProc.Stop();
-            }
+                mainLog.Debug("Shutting down all bot processes.");
+                foreach (var botProc in botProcs)
+                {
+                    botProc.Stop();
+                }
 
-            mainLog.Dispose();
+                mainLog.Dispose();
+            }
             mainLog = null;
         }
 


### PR DESCRIPTION
If there is no settings.json(user did not rename settings-template.json) the console will show a message and crash after pressing Enter. This PR fixes that(tested).

(As a side note: it is really weird that everyone renamed settings-template.json and no one caught this error)