### PR TITLE
Added a delay between failed logins

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -719,7 +719,8 @@ namespace SteamBot
                     CloseTrade();
                     Log.Warn("Disconnected from Steam Network!");
                 }
-
+                
+                Thread.Sleep(60 * 1000);
                 SteamClient.Connect ();
             });
             #endregion

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -713,14 +713,15 @@ namespace SteamBot
 
             msg.Handle<SteamClient.DisconnectedCallback> (callback =>
             {
+                var mobileAuthCode = GetMobileAuthCode();
                 if(IsLoggedIn)
                 {
                     IsLoggedIn = false;
                     CloseTrade();
                     Log.Warn("Disconnected from Steam Network!");
-                }
-                
-                Thread.Sleep(60 * 1000);
+				} else if(string.IsNullOrEmpty(mobileAuthCode)) {						
+					Thread.Sleep(60 * 1000);
+				}
                 SteamClient.Connect ();
             });
             #endregion


### PR DESCRIPTION
We got locked out by Steam several times while trying to configure our bots for the new mobile auth because Steambot tries to log in every second. With this change there will only be logins every minute. This will give the user enough time to set up mobile auth without bombing the steam api in the process :)