### PR TITLE
Added null check for mainLog in Bot.cs

### DIFF
--- a/SteamBot/BotManager.cs
+++ b/SteamBot/BotManager.cs
@@ -99,13 +99,16 @@ namespace SteamBot
         /// </summary>
         public void StopBots()
         {
-            mainLog.Debug("Shutting down all bot processes.");
-            foreach (var botProc in botProcs)
+            if (mainLog != null)
             {
-                botProc.Stop();
-            }
+                mainLog.Debug("Shutting down all bot processes.");
+                foreach (var botProc in botProcs)
+                {
+                    botProc.Stop();
+                }
 
-            mainLog.Dispose();
+                mainLog.Dispose();
+            }
             mainLog = null;
         }
 


### PR DESCRIPTION
If settings.json is not present, console will show a message instructing the user to rename settings-template.json. After pressing Enter, the console crashes because configObject is empty.

Fixes #864.