### PR TITLE
Poll trade offer status automatically

### DIFF
--- a/Bin/Debug/settings-template.json
+++ b/Bin/Debug/settings-template.json
@@ -17,6 +17,7 @@
             "MaximumActionGap":30,
             "DisplayNamePrefix":"[AutomatedBot] ",
             "TradePollingInterval":800,
+            "TradeOfferPollingIntervalSecs":30,
             "ConsoleLogLevel":"Success",
             "FileLogLevel":"Info",
             "AutoStart": "true",

--- a/Bin/Release/settings-template.json
+++ b/Bin/Release/settings-template.json
@@ -17,9 +17,11 @@
             "MaximumActionGap":30,
             "DisplayNamePrefix":"[AutomatedBot] ",
             "TradePollingInterval":800,
+            "TradeOfferPollingIntervalSecs":30,
             "ConsoleLogLevel":"Success",
             "FileLogLevel":"Info",
-            "AutoStart": "true"
+            "AutoStart": "true",
+            "SchemaLang":"en"
         }
     ]
 }

--- a/SteamBot/AdminUserHandler.cs
+++ b/SteamBot/AdminUserHandler.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using SteamKit2;
 using SteamTrade;
 using System.Collections.Generic;
+using SteamTrade.TradeOffer;
 
 namespace SteamBot
 {
@@ -129,9 +130,12 @@ namespace SteamBot
             Trade.SetReady(true);
         }
 
-        public override void OnTradeSuccess()
+        public override void OnTradeOfferUpdated(TradeOffer offer)
         {
-            Log.Success("Trade Complete.");
+            if(offer.OfferState == TradeOfferState.TradeOfferStateAccepted)
+            {
+                Log.Success("Trade Complete.");
+            }
         }
 
         public override void OnTradeAwaitingConfirmation(long tradeOfferID)

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -993,18 +993,18 @@ namespace SteamBot
         {
             if (offer.OfferState == TradeOfferState.TradeOfferStateActive)
             {
-                GetUserHandler(offer.PartnerSteamId).OnNewTradeOffer(offer);
+                GetUserHandler(offer.PartnerSteamId).OnTradeOfferUpdated(offer);
             }
         }
         public void SubscribeTradeOffer(TradeOfferManager tradeOfferManager)
         {
-            tradeOfferManager.OnNewTradeOffer += TradeOfferRouter;
+            tradeOfferManager.OnTradeOfferUpdated += TradeOfferRouter;
         }
 
         //todo: should unsubscribe eventually...
         public void UnsubscribeTradeOffer(TradeOfferManager tradeOfferManager)
         {
-            tradeOfferManager.OnNewTradeOffer -= TradeOfferRouter;
+            tradeOfferManager.OnTradeOfferUpdated -= TradeOfferRouter;
         }
 
         /// <summary>
@@ -1012,7 +1012,6 @@ namespace SteamBot
         /// </summary>
         public void SubscribeTrade (Trade trade, UserHandler handler)
         {
-            trade.OnSuccess += handler.OnTradeSuccess;
             trade.OnAwaitingConfirmation += handler._OnTradeAwaitingConfirmation;
             trade.OnClose += handler.OnTradeClose;
             trade.OnError += handler.OnTradeError;
@@ -1031,7 +1030,6 @@ namespace SteamBot
         /// </summary>
         public void UnsubscribeTrade (UserHandler handler, Trade trade)
         {
-            trade.OnSuccess -= handler.OnTradeSuccess;
             trade.OnAwaitingConfirmation -= handler._OnTradeAwaitingConfirmation;
             trade.OnClose -= handler.OnTradeClose;
             trade.OnError -= handler.OnTradeError;
@@ -1053,7 +1051,7 @@ namespace SteamBot
             var inventory = Inventory.FetchInventory(SteamUser.SteamID, ApiKey, SteamWeb);
             if(inventory.IsPrivate)
             {
-                log.Warn("The bot's backpack is private! If your bot adds any items it will fail! Your bot's backpack should be Public.");
+                Log.Warn("The bot's backpack is private! If your bot adds any items it will fail! Your bot's backpack should be Public.");
             }
             return inventory;
         }

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -378,7 +378,7 @@ namespace SteamBot
 
         protected void SpawnTradeOfferPollingThread()
         {
-            if (tradeOfferThread != null)
+            if (tradeOfferThread == null)
             {
                 tradeOfferThread = new Thread(TradeOfferPollingFunction);
                 tradeOfferThread.Start();
@@ -616,25 +616,25 @@ namespace SteamBot
                                 RemoveUserHandler(friend.SteamID);
                             }
                             else if (friend.Relationship == EFriendRelationship.RequestRecipient)
-                    {
+                            {
                                 if (GetUserHandler(friend.SteamID).OnFriendAdd())
                                 {
-                        if (!friends.Contains(friend.SteamID))
-                        {
-                            friends.Add(friend.SteamID);
+                                    if (!friends.Contains(friend.SteamID))
+                                    {
+                                        friends.Add(friend.SteamID);
                                     }
-                                    else
-                            {
-                                        Log.Error("Friend was added who was already in friends list: " + friend.SteamID);
+                                    SteamFriends.AddFriend(friend.SteamID);
+                                }
+                                else
+                                {
+                                    if(friends.Contains(friend.SteamID))
+                                    {
+                                        friends.Remove(friend.SteamID);
                                     }
-                                SteamFriends.AddFriend(friend.SteamID);
-                            }
-                        else
-                        {
                                     SteamFriends.RemoveFriend(friend.SteamID);
-                                RemoveUserHandler(friend.SteamID);
+                                    RemoveUserHandler(friend.SteamID);
+                                }
                             }
-                        }
                             break;
                     }
                 }
@@ -938,7 +938,7 @@ namespace SteamBot
             return true;
         }
 
-        UserHandler GetUserHandler(SteamID sid)
+        public UserHandler GetUserHandler(SteamID sid)
         {
             if (!userHandlers.ContainsKey(sid))
                 userHandlers[sid] = createHandler(this, sid);
@@ -1012,10 +1012,7 @@ namespace SteamBot
 
         public void TradeOfferRouter(TradeOffer offer)
         {
-            if (offer.OfferState == TradeOfferState.TradeOfferStateActive)
-            {
-                GetUserHandler(offer.PartnerSteamId).OnTradeOfferUpdated(offer);
-            }
+            GetUserHandler(offer.PartnerSteamId).OnTradeOfferUpdated(offer);
         }
         public void SubscribeTradeOffer(TradeOfferManager tradeOfferManager)
         {
@@ -1223,7 +1220,13 @@ namespace SteamBot
                     {
                         HandleSteamMessage(msg);
                     }
-                    tradeOfferManager.HandleNextPendingTradeOfferUpdate();
+
+                    if(tradeOfferManager != null)
+                    {
+                        tradeOfferManager.HandleNextPendingTradeOfferUpdate();
+                    }
+
+                    Thread.Sleep(1);
                 }
                 catch (WebException e)
                 {

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -158,6 +158,7 @@ namespace SteamBot
             public int MaximumActionGap { get; set; }
             public string DisplayNamePrefix { get; set; }
             public int TradePollingInterval { get; set; }
+            public int TradeOfferPollingIntervalSecs { get; set; }
             public string ConsoleLogLevel { get; set; }
             public string FileLogLevel { get; set; }
             [JsonConverter(typeof(JsonToSteamID))]

--- a/SteamBot/SimpleUserHandler.cs
+++ b/SteamBot/SimpleUserHandler.cs
@@ -1,6 +1,7 @@
 using SteamKit2;
 using System.Collections.Generic;
 using SteamTrade;
+using SteamTrade.TradeOffer;
 using SteamTrade.TradeWebAPI;
 
 namespace SteamBot
@@ -82,15 +83,32 @@ namespace SteamBot
             }
         }
 
-        public override void OnTradeSuccess()
-        {
-            Log.Success("Trade Complete.");
-        }
-
         public override void OnTradeAwaitingConfirmation(long tradeOfferID)
         {
             Log.Warn("Trade ended awaiting confirmation");
             SendChatMessage("Please complete the confirmation to finish the trade");
+        }
+
+        public override void OnTradeOfferUpdated(TradeOffer offer)
+        {
+            switch (offer.OfferState)
+            {
+                case TradeOfferState.TradeOfferStateAccepted:
+                    Log.Info($"Trade offer {offer.TradeOfferId} has been completed!");
+                    SendChatMessage("Trade completed, thank you!");
+                    break;
+                case TradeOfferState.TradeOfferStateActive:
+                case TradeOfferState.TradeOfferStateNeedsConfirmation:
+                case TradeOfferState.TradeOfferStateInEscrow:
+                    //Trade is still active but incomplete
+                    break;
+                case TradeOfferState.TradeOfferStateCountered:
+                    Log.Info($"Trade offer {offer.TradeOfferId} was countered");
+                    break;
+                default:
+                    Log.Info($"Trade offer {offer.TradeOfferId} failed");
+                    break;
+            }
         }
 
         public override void OnTradeAccept() 

--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -1,6 +1,7 @@
 using SteamKit2;
 using System.Collections.Generic;
 using SteamTrade;
+using SteamTrade.TradeOffer;
 
 namespace SteamBot
 {
@@ -194,9 +195,12 @@ namespace SteamBot
             }
         }
 
-        public override void OnTradeSuccess()
+        public override void OnTradeOfferUpdated(TradeOffer offer)
         {
-            Log.Success("Trade Complete.");
+            if(offer.OfferState == TradeOfferState.TradeOfferStateAccepted)
+            {
+                Log.Success("Trade Complete.");
+            }
         }
 
         public override void OnTradeAwaitingConfirmation(long tradeOfferID)

--- a/SteamBot/TradeOfferUserHandler.cs
+++ b/SteamBot/TradeOfferUserHandler.cs
@@ -11,7 +11,15 @@ namespace SteamBot
     {
         public TradeOfferUserHandler(Bot bot, SteamID sid) : base(bot, sid) { }
 
-        public override void OnNewTradeOffer(TradeOffer offer)
+        public override void OnTradeOfferUpdated(TradeOffer offer)
+        {
+            if(offer.OfferState == TradeOfferState.TradeOfferStateAccepted)
+            {
+                OnNewTradeOffer(offer);
+            }
+        }
+
+        private void OnNewTradeOffer(TradeOffer offer)
         {
             //receiving a trade offer 
             if (IsAdmin)
@@ -111,8 +119,6 @@ namespace SteamBot
         public override void OnTradeError(string error) { }
 
         public override void OnTradeTimeout() { }
-
-        public override void OnTradeSuccess() { }
 
         public override void OnTradeAwaitingConfirmation(long tradeOfferID) { }
 

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -165,13 +165,12 @@ namespace SteamBot
 
 
         /// <summary>
-        /// Called when a new trade offer is received
+        /// Called when a trade offer is updated, including the first time it is seen.
+        /// When the bot is restarted, this might get called again for trade offers it's been previously called on.  Thus, you can't rely on
+        /// this method being called only once after an offer is accepted!  If you need to rely on that functionality (say for giving users non-Steam currency),
+        ///  you need to keep track of which trades have been paid out yourself
         /// </summary>
-        /// <param name="offer"></param>
-        public virtual void OnNewTradeOffer(TradeOffer offer)
-        {
-
-        }
+        public abstract void OnTradeOfferUpdated(TradeOffer offer);
 
         /// <summary>
         /// Called when a chat message is sent in a chatroom
@@ -237,8 +236,6 @@ namespace SteamBot
         }
 
         public abstract void OnTradeTimeout ();
-
-        public abstract void OnTradeSuccess ();
 
         public void _OnTradeAwaitingConfirmation(long tradeOfferID)
         {

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -240,14 +240,7 @@ namespace SteamBot
         public void _OnTradeAwaitingConfirmation(long tradeOfferID)
         {
             Bot.AcceptAllMobileTradeConfirmations();
-            TradeOffer tradeOffer;
-            if (Bot.TryGetTradeOffer(tradeOfferID.ToString(), out tradeOffer))
-            {
-                if (tradeOffer.OfferState == TradeOfferState.TradeOfferStateNeedsConfirmation)
-                {
-                    OnTradeAwaitingConfirmation(tradeOfferID);
-                }
-            }            
+            OnTradeAwaitingConfirmation(tradeOfferID);
         }
         public abstract void OnTradeAwaitingConfirmation(long tradeOfferID);
 

--- a/SteamTrade/Trade.cs
+++ b/SteamTrade/Trade.cs
@@ -247,11 +247,6 @@ namespace SteamTrade
         public event CloseHandler OnClose;
 
         /// <summary>
-        /// Called when the trade completes successfully.
-        /// </summary>
-        public event CompleteHandler OnSuccess;
-
-        /// <summary>
         /// Called when the trade ends awaiting email confirmation
         /// </summary>
         public event WaitingForEmailHandler OnAwaitingConfirmation;
@@ -848,14 +843,6 @@ namespace SteamTrade
 
                 OnUserRemoveItem(schemaItem, null);
             }
-        }
-
-        internal void FireOnSuccessEvent()
-        {
-            var onSuccessEvent = OnSuccess;
-
-            if(onSuccessEvent != null)
-                onSuccessEvent();
         }
 
         internal void FireOnAwaitingConfirmation()

--- a/SteamTrade/TradeManager.cs
+++ b/SteamTrade/TradeManager.cs
@@ -289,23 +289,28 @@ namespace SteamTrade
                 finally
                 {
                     DebugPrint("Trade thread shutting down.");
-                    try
+                    try //Yikes, that's a lot of nested 'try's.  Is there some way to clean this up?
                     {
-                        try //Yikes, that's a lot of nested 'try's.  Is there some way to clean this up?
-                        {
-                            if(trade.IsTradeAwaitingConfirmation)
-                                trade.FireOnAwaitingConfirmation();
-                        }
-                        finally
+                        if(trade.IsTradeAwaitingConfirmation)
+                            trade.FireOnAwaitingConfirmation();
+                    }
+                    catch(Exception ex)
+                    {
+                        trade.FireOnErrorEvent("Unknown error occurred during OnTradeAwaitingConfirmation: " + ex.ToString());
+                    }
+                    finally
+                    {
+                        try
                         {
                             //Make sure OnClose is always fired after OnSuccess, even if OnSuccess throws an exception
                             //(which it NEVER should, but...)
                             trade.FireOnCloseEvent();
                         }
-                    }
-                    catch(Exception ex)
-                    {
-                        trade.FireOnErrorEvent("Unknown error occurred DURING CLEANUP(!?): " + ex.ToString());
+                        catch (Exception e)
+                        {
+                            DebugError("Error occurred during trade.OnClose()! " + e);
+                            throw;
+                        }
                     }
                 }
             });
@@ -364,6 +369,11 @@ namespace SteamTrade
             // #define DEBUG_TRADE_MANAGER
             // at the first line of this file.
             System.Console.WriteLine (output);
+        }
+
+        private static void DebugError(string output)
+        {
+            System.Console.WriteLine(output);
         }
     }
 }

--- a/SteamTrade/TradeManager.cs
+++ b/SteamTrade/TradeManager.cs
@@ -293,9 +293,7 @@ namespace SteamTrade
                     {
                         try //Yikes, that's a lot of nested 'try's.  Is there some way to clean this up?
                         {
-                            if(trade.HasTradeCompletedOk)
-                                trade.FireOnSuccessEvent();
-                            else if(trade.IsTradeAwaitingConfirmation)
+                            if(trade.IsTradeAwaitingConfirmation)
                                 trade.FireOnAwaitingConfirmation();
                         }
                         finally

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -48,7 +48,7 @@ namespace SteamTrade.TradeOffer
 
         private void AddTradeOffersToQueue(OffersResponse offers)
         {
-            if (offers?.AllOffers == null)
+            if (offers == null || offers.AllOffers == null)
                 return;
 
             lock(unhandledTradeOfferUpdates)

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -43,7 +43,7 @@ namespace SteamTrade.TradeOffer
                 : webApi.GetAllTradeOffers(GetUnixTimeStamp(LastTimeCheckedOffers).ToString()));
             AddTradeOffersToQueue(offersResponse);
 
-            LastTimeCheckedOffers = startTime;
+            LastTimeCheckedOffers = startTime - TimeSpan.FromMinutes(5); //Lazy way to make sure we don't miss any trade offers due to slightly differing clocks
         }
 
         private void AddTradeOffersToQueue(OffersResponse offers)

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -30,6 +30,12 @@ namespace SteamTrade.TradeOffer
         /// </summary>
         public event NewOfferHandler OnNewTradeOffer;
 
+        public bool GetAllTradeOffers()
+        {
+            var offers = webApi.GetAllTradeOffers();
+            return HandleTradeOffersResponse(offers);
+        }
+
         /// <summary>
         /// Gets the currently active trade offers from the web api and processes them
         /// </summary>
@@ -44,7 +50,7 @@ namespace SteamTrade.TradeOffer
         /// </summary>
         public bool GetTradeOffersSince(DateTime dateTime)
         {
-            var offers = webApi.GetTradeOffers(false, true, false, true, false, GetUnixTimeStamp(dateTime).ToString());
+            var offers = webApi.GetAllTradeOffers(GetUnixTimeStamp(dateTime).ToString());
             return HandleTradeOffersResponse(offers);
         }
 
@@ -81,7 +87,7 @@ namespace SteamTrade.TradeOffer
 
         public bool GetOffers()
         {
-            bool offersChecked = (LastTimeCheckedOffers == DateTime.MinValue ? GetActiveTradeOffers() : GetTradeOffersSince(LastTimeCheckedOffers));
+            bool offersChecked = (LastTimeCheckedOffers == DateTime.MinValue ? GetAllTradeOffers() : GetTradeOffersSince(LastTimeCheckedOffers));
 
             if(offersChecked)
                 LastTimeCheckedOffers = DateTime.Now;

--- a/SteamTrade/TradeOffer/TradeOfferManager.cs
+++ b/SteamTrade/TradeOffer/TradeOfferManager.cs
@@ -24,12 +24,12 @@ namespace SteamTrade.TradeOffer
             session = new OfferSession(webApi, steamWeb);
         }
 
-        public delegate void NewOfferHandler(TradeOffer offer);
+        public delegate void TradeOfferUpdatedHandler(TradeOffer offer);
 
         /// <summary>
         /// Occurs when a new trade offer has been made by the other user
         /// </summary>
-        public event NewOfferHandler OnNewTradeOffer;
+        public event TradeOfferUpdatedHandler OnTradeOfferUpdated;
 
         public bool GetAllTradeOffers()
         {
@@ -107,7 +107,7 @@ namespace SteamTrade.TradeOffer
         {
             var tradeOffer = new TradeOffer(session, offer);
             knownTradeOffers[offer.TradeOfferId] = offer.TradeOfferState;
-            OnNewTradeOffer(tradeOffer);
+            OnTradeOfferUpdated(tradeOffer);
         }
 
         private uint GetUnixTimeStamp(DateTime dateTime)

--- a/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
+++ b/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace SteamTrade.TradeOffer
 {
@@ -193,6 +194,19 @@ namespace SteamTrade.TradeOffer
 
         [JsonProperty("descriptions")]
         public List<AssetDescription> Descriptions { get; set; }
+
+        public IEnumerable<Offer> AllOffers
+        {
+            get
+            {
+                if (TradeOffersSent == null)
+                {
+                    return TradeOffersReceived;
+                }
+
+                return (TradeOffersReceived == null ? TradeOffersSent : TradeOffersSent.Union(TradeOffersReceived));
+            }
+        }
     }
 
     public class Offer

--- a/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
+++ b/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
@@ -53,26 +53,7 @@ namespace SteamTrade.TradeOffer
 
         public OffersResponse GetActiveTradeOffers(bool getSentOffers, bool getReceivedOffers, bool getDescriptions, string language = "en_us")
         {
-            if (!getSentOffers && !getReceivedOffers)
-            {
-                throw new ArgumentException("getSentOffers and getReceivedOffers can't be both false");
-            }
-
-            string options = string.Format("?key={0}&get_sent_offers={1}&get_received_offers={2}&get_descriptions={3}&language={4}&active_only={5}",
-                apiKey, BoolConverter(getSentOffers), BoolConverter(getReceivedOffers), BoolConverter(getDescriptions), language, BoolConverter(true));
-            string url = string.Format(BaseUrl, "GetTradeOffers", "v1", options);
-            string response = steamWeb.Fetch(url, "GET", null, false);
-            try
-            {
-                var result = JsonConvert.DeserializeObject<ApiResponse<OffersResponse>>(response);
-                return result.Response;
-            }
-            catch (Exception ex)
-            {
-                //todo log
-                Debug.WriteLine(ex);
-            }
-            return new OffersResponse();
+            return GetTradeOffers(getSentOffers, getReceivedOffers, getDescriptions, true, false, "1389106496", language);
         }
 
         public OffersResponse GetTradeOffers(bool getSentOffers, bool getReceivedOffers, bool getDescriptions, bool activeOnly, bool historicalOnly, string timeHistoricalCutoff = "1389106496", string language = "en_us")

--- a/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
+++ b/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
@@ -51,6 +51,11 @@ namespace SteamTrade.TradeOffer
             return TradeOfferState.TradeOfferStateUnknown;
         }
 
+        public OffersResponse GetAllTradeOffers(string timeHistoricalCutoff = "1389106496", string language = "en_us")
+        {
+            return GetTradeOffers(true, true, false, true, true, timeHistoricalCutoff, language);
+        }
+
         public OffersResponse GetActiveTradeOffers(bool getSentOffers, bool getReceivedOffers, bool getDescriptions, string language = "en_us")
         {
             return GetTradeOffers(getSentOffers, getReceivedOffers, getDescriptions, true, false, "1389106496", language);


### PR DESCRIPTION
Changes suggested in #914 

I've been testing for a few days, and it seems to work fine.  Anyone care to test?  You no longer need to call `TradeOfferManager.GetOffers()`, it's done automatically.  You just need to handle `UserHandler.OnTradeOfferUpdated()`