### PR TITLE
Remove redundant botThread.RunWorkerAsync() in Bot

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -206,7 +206,6 @@ namespace SteamBot
             botThread = new BackgroundWorker { WorkerSupportsCancellation = true };
             botThread.DoWork += BackgroundWorkerOnDoWork;
             botThread.RunWorkerCompleted += BackgroundWorkerOnRunWorkerCompleted;
-            botThread.RunWorkerAsync();
         }
 
         ~Bot()


### PR DESCRIPTION
Call to botThread.RunWorkerAsync() in Bot constructor is not needed, as it's called in Bot.StartBot().