### PR TITLE
Improve OnTradeOfferUpdated mimicking OnNewTradeOffer

### DIFF
--- a/SteamBot/TradeOfferUserHandler.cs
+++ b/SteamBot/TradeOfferUserHandler.cs
@@ -13,7 +13,7 @@ namespace SteamBot
 
         public override void OnTradeOfferUpdated(TradeOffer offer)
         {
-            if(offer.OfferState == TradeOfferState.TradeOfferStateAccepted)
+            if(offer.OfferState == TradeOfferState.TradeOfferStateActive && !offer.IsOurOffer)
             {
                 OnNewTradeOffer(offer);
             }


### PR DESCRIPTION
OnNewTradeOffer previously was fired when tradeoffers came in that were active. 
Before this commint, outgoing and incoming offers that were already accepted showed up in this event.