### PR TITLE
GenericInventory improvements.

### DIFF
--- a/SteamBot/SteamTradeDemoHandler.cs
+++ b/SteamBot/SteamTradeDemoHandler.cs
@@ -81,10 +81,10 @@ namespace SteamBot
             contextId.Add(1);
             contextId.Add(6);
 
-            mySteamInventory.load(753, contextId, Bot.SteamClient.SteamID);
-            OtherSteamInventory.load(753, contextId, OtherSID);
+            mySteamInventory.Load(753, contextId, Bot.SteamClient.SteamID);
+            OtherSteamInventory.Load(753, contextId, OtherSID);
 
-            if (!mySteamInventory.isLoaded | !OtherSteamInventory.isLoaded)
+            if (!mySteamInventory.IsLoaded | !OtherSteamInventory.IsLoaded)
             {
                 SendTradeMessage("Couldn't open an inventory, type 'errors' for more info.");
             }
@@ -109,10 +109,10 @@ namespace SteamBot
                     break;
 
                 case 753:
-                    GenericInventory.ItemDescription tmpDescription = OtherSteamInventory.getDescription(inventoryItem.Id);
+                    GenericInventory.ItemDescription tmpDescription = OtherSteamInventory.GetDescription(inventoryItem.Id);
                     SendTradeMessage("Steam Inventory Item Added.");
-                    SendTradeMessage("Type: {0}", tmpDescription.type);
-                    SendTradeMessage("Marketable: {0}", (tmpDescription.marketable ? "Yes" : "No"));
+                    SendTradeMessage("Type: {0}", tmpDescription.Type);
+                    SendTradeMessage("Marketable: {0}", (tmpDescription.Marketable ? "Yes" : "No"));
                     break;
 
                 default:

--- a/SteamBotUnitTest/SteamTrade/GenericInventoryTest.cs
+++ b/SteamBotUnitTest/SteamTrade/GenericInventoryTest.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using SteamKit2;
+using SteamTrade;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SteamBotUnitTest.SteamTrade
+{
+    [TestFixture]
+    class GenericInventoryTest
+    {
+        [Test]
+        public void LoadTest()
+        {
+            var inventory = new GenericInventory(new SteamWeb());
+            //76561198104350201 is my friend's Steam account with lots of Dota2 items which will test the start/more way of loading. It's inventory will remain public and contain more than 2000 items long term.
+            inventory.Load(570, new long[] { 2 }, new SteamID(76561198104350201));
+            Assert.True(inventory.Errors.Count == 0 && inventory.Items.Count > 0 && inventory.Descriptions.Count > 0, string.Join("\r\n", inventory.Errors));
+            Assert.True(inventory.Items.All(i => inventory.GetDescription(i.Value.assetid) != null));
+        }
+    }
+}

--- a/SteamBotUnitTest/SteamTradeUnitTest.csproj
+++ b/SteamBotUnitTest/SteamTradeUnitTest.csproj
@@ -33,8 +33,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.4.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.4.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.0.0.668, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="SteamKit2, Version=1.7.0.33680, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SteamKit2.1.7.0\lib\net45\SteamKit2.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -46,9 +55,12 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SteamTrade\GenericInventoryTest.cs" />
     <Compile Include="SteamTrade\TF2ValueTests.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SteamTrade\SteamTrade.csproj">
       <Project>{6cec0333-81eb-40ee-85d1-941363626fc7}</Project>

--- a/SteamBotUnitTest/packages.config
+++ b/SteamBotUnitTest/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnit" version="3.4.0" targetFramework="net451" />
+  <package id="protobuf-net" version="2.0.0.668" targetFramework="net451" />
+  <package id="SteamKit2" version="1.7.0" targetFramework="net451" />
 </packages>

--- a/SteamTrade/GenericInventory.cs
+++ b/SteamTrade/GenericInventory.cs
@@ -5,14 +5,24 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using SteamKit2;
 using SteamTrade.TradeWebAPI;
+using System.ComponentModel;
+using System.Net;
+using Newtonsoft.Json.Linq;
 
 namespace SteamTrade
 {
+    /// <summary>
+    /// Generic Steam Backpack Interface.
+    /// </summary>
+    public class GenericInventory : GenericInventory<ItemDescription>
+    {
+        public GenericInventory(SteamWeb steamWeb) : base(steamWeb) { }
+    }
 
     /// <summary>
-    /// Generic Steam Backpack Interface
+    /// Generic Steam Backpack Interface. <see cref="T"/> is your own implementation of <see cref="ItemDescription"/>. See documentation on <see cref="ItemDescription"/> for more details.
     /// </summary>
-    public class GenericInventory
+    public class GenericInventory<T> where T : ItemDescription
     {
         private readonly SteamWeb SteamWeb;
 
@@ -21,7 +31,10 @@ namespace SteamTrade
             SteamWeb = steamWeb;
         }
 
-        public Dictionary<ulong, Item> items
+        [Obsolete("Use Items instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dictionary<ulong, Item> items => Items;
+        public Dictionary<ulong, Item> Items
         {
             get
             {
@@ -32,7 +45,13 @@ namespace SteamTrade
             }
         }
 
-        public Dictionary<string, ItemDescription> descriptions
+        [Obsolete("Use Descriptions instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Dictionary<string, T> descriptions => Descriptions;
+        /// <summary>
+        /// More details of all <see cref="Items"/>. Key is <see cref="Item.DescriptionId"/>.
+        /// </summary>
+        public Dictionary<string, T> Descriptions
         {
             get
             {
@@ -43,7 +62,10 @@ namespace SteamTrade
             }
         }
 
-        public List<string> errors
+        [Obsolete("Use Errors instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public List<string> errors => Errors;
+        public List<string> Errors
         {
             get
             {
@@ -54,87 +76,97 @@ namespace SteamTrade
             }
         }
 
-        public bool isLoaded = false;
+        [Obsolete("Use IsLoaded instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool isLoaded => IsLoaded;
+        public bool IsLoaded { get; private set; } = false;
 
         private Task _loadTask;
-        private Dictionary<string, ItemDescription> _descriptions = new Dictionary<string, ItemDescription>();
+        private Dictionary<string, T> _descriptions = new Dictionary<string, T>();
         private Dictionary<ulong, Item> _items = new Dictionary<ulong, Item>();
         private List<string> _errors = new List<string>();
 
+        /// <summary>
+        /// Class containing basic information about an item. For more details, use <see cref="DescriptionId"/> as dictionary key to access <see cref="GenericInventory{T}.Descriptions"/>.
+        /// </summary>
         public class Item : TradeUserAssets
         {
             public Item(int appid, long contextid, ulong assetid, string descriptionid, int amount = 1) : base(appid, contextid, assetid, amount)
             {
-                this.descriptionid = descriptionid;
+                this.DescriptionId = descriptionid;
             }
 
-            public string descriptionid { get; private set; }
+            [Obsolete("Use DescriptionId instead.")]
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            public string descriptionid => DescriptionId;
+            /// <summary>
+            /// Use this as dictionary key to access <see cref="GenericInventory{T}.Descriptions"/>.
+            /// </summary>
+            public string DescriptionId { get; private set; }
 
             public override string ToString()
             {
                 return string.Format("id:{0}, appid:{1}, contextid:{2}, amount:{3}, descriptionid:{4}",
-                    assetid, appid, contextid, amount, descriptionid);
+                    assetid, appid, contextid, amount, DescriptionId);
             }
         }
 
-        public class ItemDescription
-        {
-            public string name { get; set; }
-            public string type { get; set; }
-            public bool tradable { get; set; }
-            public bool marketable { get; set; }
-            public string url { get; set; }
-            public long classid { get; set; }
-
-            public Dictionary<string, string> app_data { get; set; }
-
-            public void debug_app_data()
-            {
-                Console.WriteLine("\n\"" + name + "\"");
-                if (app_data == null)
-                {
-                    Console.WriteLine("Doesn't have app_data");
-                    return;
-                }
-
-                foreach (var value in app_data)
-                {
-                    Console.WriteLine(string.Format("{0} = {1}", value.Key, value.Value));
-                }
-                Console.WriteLine("");
-            }
-        }
+        [Obsolete("Use GetDescription instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public ItemDescription getDescription(ulong assetId) { return GetDescription(assetId); }
 
         /// <summary>
         /// Returns information (such as item name, etc) about the given item.
-        /// This call can fail, usually when the user's inventory is private.
+        /// If no description with the given <param name="assetId"></param> is found, return null.
         /// </summary>
-        public ItemDescription getDescription(ulong id)
+        public T GetDescription(ulong assetId)
         {
             if (_loadTask == null)
                 return null;
             _loadTask.Wait();
 
-            try
-            {
-                return _descriptions[_items[id].descriptionid];
-            }
-            catch
-            {
+            Item item;
+            if (!_items.TryGetValue(assetId, out item))
                 return null;
-            }
+            T description;
+            if (!_descriptions.TryGetValue(item.DescriptionId, out description))
+                return null;
+            return description;
         }
 
-        public void load(int appid, IEnumerable<long> contextIds, SteamID steamid)
+        [Obsolete("Use Load(int, IEnumerable<long>, SteamID) instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void load(int appid, IEnumerable<long> contextIds, SteamID steamid) { Load(appid, contextIds, steamid); }
+        /// <summary>
+        /// Load this <see cref="GenericInventory"/>. Results will be stored in <see cref="Items"/> and <see cref="Descriptions"/>. You should check <see cref="Errors"/> for failures. No exception will be thrown.
+        /// </summary>
+        /// <param name="contextIds">Inspect the network data in the web browser inventory page to determine what context IDs to use.</param>
+        /// <param name="steamid">Steam ID of whose inventory is to load.</param>
+        /// <param name="maxRetryCountForWebExceptions">Due to the fact that the data to download is relatively huge and Steam's servers are often unstable, a retry is used when sending HTTP requests.</param>
+        public void Load(int appid, IEnumerable<long> contextIds, SteamID steamid, int maxRetryCountForWebExceptions = 2)
         {
             List<long> contextIdsCopy = contextIds.ToList();
-            _loadTask = Task.Factory.StartNew(() => loadImplementation(appid, contextIdsCopy, steamid));
+            _loadTask = Task.Factory.StartNew(() => LoadImplementation(appid, contextIdsCopy, steamid, maxRetryCountForWebExceptions));
         }
 
-        public void loadImplementation(int appid, IEnumerable<long> contextIds, SteamID steamid)
+        /// <summary>
+        /// Load this <see cref="GenericInventory"/> asynchronously. Results will be stored in <see cref="Items"/> and <see cref="Descriptions"/>. You should check <see cref="Errors"/> for failures. No exception will be thrown.
+        /// </summary>
+        /// <param name="contextIds">Inspect the network data in the web browser inventory page to determine what context IDs to use.</param>
+        /// <param name="steamid">Steam ID of whose inventory is to load.</param>
+        /// <param name="maxRetryCountForWebExceptions">Due to the fact that the data to download is relatively huge and Steam's servers are often unstable, a retry is used when sending HTTP requests.</param>
+        public Task LoadAsync(int appid, IEnumerable<long> contextIds, SteamID steamid, int maxRetryCountForWebExceptions = 2) { Load(appid, contextIds, steamid, maxRetryCountForWebExceptions); return _loadTask; }
+
+        [Obsolete("Use LoadAsync(int, IEnumerable<long>, SteamID, int) and call Task.Wait() instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void loadImplementation(int appid, IEnumerable<long> contextIds, SteamID steamid) { LoadImplementation(appid, contextIds, steamid); }
+        /// <summary>
+        /// Before overriding this method, be sure to read the source code first.
+        /// </summary>
+        protected virtual void LoadImplementation(int appid, IEnumerable<long> contextIds, SteamID steamid, int maxRetryCountForWebExceptions = 2)
         {
             dynamic invResponse;
-            isLoaded = false;
+            IsLoaded = false;
             Dictionary<string, string> tmpAppData;
 
             _items.Clear();
@@ -145,61 +177,77 @@ namespace SteamTrade
             {
                 foreach (long contextId in contextIds)
                 {
-                    string response = SteamWeb.Fetch(string.Format("http://steamcommunity.com/profiles/{0}/inventory/json/{1}/{2}/", steamid.ConvertToUInt64(), appid, contextId), "GET", null, true);
-                    invResponse = JsonConvert.DeserializeObject(response);
-
-                    if (invResponse.success == false)
+                    var start = 0;
+                    while (true)
                     {
-                        _errors.Add("Fail to open backpack: " + invResponse.Error);
-                        continue;
-                    }
-
-                    //rgInventory = Items on Steam Inventory 
-                    foreach (var item in invResponse.rgInventory)
-                    {
-
-                        foreach (var itemId in item)
+                        string response;
+                        var timesRetried = 0;
+                        retry:
+                        try
                         {
-                            string descriptionid = itemId.classid + "_" + itemId.instanceid;
-                            _items.Add((ulong)itemId.id, new Item(appid, contextId, (ulong)itemId.id, descriptionid));
-                            break;
+                            response = SteamWeb.Fetch($"http://steamcommunity.com/profiles/{steamid.ConvertToUInt64()}/inventory/json/{appid}/{contextId}{(start == 0 ? "" : $"?start={start}")}", "GET", null, true);
                         }
-                    }
-
-                    // rgDescriptions = Item Schema (sort of)
-                    foreach (var description in invResponse.rgDescriptions)
-                    {
-                        foreach (var class_instance in description)// classid + '_' + instenceid 
+                        catch (WebException)
                         {
-                            if (class_instance.app_data != null)
-                            {
-                                tmpAppData = new Dictionary<string, string>();
-                                foreach (var value in class_instance.app_data)
-                                {
-                                    tmpAppData.Add("" + value.Name, "" + value.Value);
-                                }
-                            }
+                            if (timesRetried >= maxRetryCountForWebExceptions)
+                                throw;
                             else
-                            {
-                                tmpAppData = null;
-                            }
-
-                            _descriptions.Add("" + (class_instance.classid ?? '0') + "_" + (class_instance.instanceid ?? '0'),
-                                new ItemDescription()
-                                {
-                                    name = class_instance.name,
-                                    type = class_instance.type,
-                                    marketable = (bool)class_instance.marketable,
-                                    tradable = (bool)class_instance.tradable,
-                                    classid = long.Parse((string)class_instance.classid),
-                                    url = (class_instance.actions != null && class_instance.actions.First["link"] != null ? class_instance.actions.First["link"] : ""),
-                                    app_data = tmpAppData
-                                }
-                            );
-                            break;
+                                timesRetried++;
+                            goto retry;
                         }
-                    }
+                        invResponse = JsonConvert.DeserializeObject(response);
 
+                        if (invResponse.success == false)
+                        {
+                            _errors.Add("Fail to open backpack: " + invResponse.Error);
+                            continue;
+                        }
+
+                        //rgInventory = Items on Steam Inventory 
+                        foreach (var item in invResponse.rgInventory)
+                        {
+
+                            foreach (var itemId in item)
+                            {
+                                string descriptionid = itemId.classid + "_" + itemId.instanceid;
+                                _items.Add((ulong)itemId.id, new Item(appid, contextId, (ulong)itemId.id, descriptionid));
+                                break;
+                            }
+                        }
+
+                        // rgDescriptions = Item Schema (sort of)
+                        foreach (var description in invResponse.rgDescriptions)
+                        {
+                            foreach (var class_instance in description)// classid + '_' + instenceid 
+                            {
+                                if (class_instance.app_data != null)
+                                {
+                                    tmpAppData = new Dictionary<string, string>();
+                                    foreach (var value in class_instance.app_data)
+                                    {
+                                        tmpAppData.Add("" + value.Name, "" + value.Value);
+                                    }
+                                }
+                                else
+                                {
+                                    tmpAppData = null;
+                                }
+                                var descriptionObject = ((JObject)class_instance).ToObject<T>();
+                                descriptionObject.Url = (class_instance.actions != null && class_instance.actions.First["link"] != null ? class_instance.actions.First["link"] : "");
+                                descriptionObject.AppData = tmpAppData;
+                                descriptionObject.Descriptions = class_instance.descriptions as JArray;
+                                descriptionObject.Tags = class_instance.tags as JArray;
+                                _descriptions[(string)((class_instance.classid ?? '0') + "_" + (class_instance.instanceid ?? '0'))] = descriptionObject;
+                                break;
+                            }
+                        }
+
+                        //Check for more
+                        if ((bool)invResponse.more)
+                            start = (int)invResponse.more_start;
+                        else
+                            break;
+                    }
                 }//end for (contextId)
             }//end try
             catch (Exception e)
@@ -207,7 +255,112 @@ namespace SteamTrade
                 Console.WriteLine(e.Message);
                 _errors.Add("Exception: " + e.Message);
             }
-            isLoaded = true;
+            IsLoaded = true;
+        }
+    }
+
+    /// <summary>
+    /// This class is used to deserialize item descriptions from JSON using <see cref="Newtonsoft.Json"/>. You may inherit this class to include more app specific information. Use <see cref="JsonPropertyAttribute"/> on its properties.
+    /// For a sample JSON response, hit http://steamcommunity.com/profiles/76561198104350201/inventory/json/570/2
+    /// </summary>
+    public class ItemDescription
+    {
+        [Obsolete("Use Name instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public string name => Name;
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        [Obsolete("Use Type instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public string type => Type;
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [Obsolete("Use Tradable instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public bool tradable => Tradable;
+        [JsonProperty("tradable")]
+        public bool Tradable { get; set; }
+        [Obsolete("Use Marketable instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public bool marketable => Marketable;
+        [JsonProperty("marketable")]
+        public bool Marketable { get; set; }
+        [Obsolete("Use DescriptionId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public string url => Url;
+        public string Url { get; set; }
+        [Obsolete("Use ClassId instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public long classid => ClassId;
+        [JsonProperty("classid")]
+        public long ClassId { get; set; }
+
+        [JsonProperty("appid")]
+        public int AppId { get; set; }
+        [JsonProperty("instanceid")]
+        public long InstanceId { get; set; }
+        [JsonProperty("icon_url")]
+        public string IconUrl { get; set; }
+        [JsonProperty("icon_url_large")]
+        public string IconUrlLarge { get; set; }
+        [JsonProperty("icon_drag_url")]
+        public string IconDragUrl { get; set; }
+        [JsonProperty("market_hash_name")]
+        public string MarketHashName { get; set; }
+        [JsonProperty("market_name")]
+        public string MarketName { get; set; }
+        [JsonProperty("name_color")]
+        public string NameColor { get; set; }
+        [JsonProperty("background_color")]
+        public string BackgroundColor { get; set; }
+        [JsonProperty("commodity")]
+        public string Commodity { get; set; }
+        [JsonProperty("market_tradable_restriction")]
+        public string MarketTradableRestriction { get; set; }
+        [JsonProperty("market_marketable_restriction")]
+        public string MarketMarketableRestriction { get; set; }
+
+        [JsonIgnore]
+        /// <summary>
+        /// Some apps may contain this type of descriptions. It's your responsiblity to parse it. 
+        /// This property can be null when not applicable.
+        /// </summary>
+        public JArray Descriptions { get; set; }
+
+        [JsonIgnore]
+        /// <summary>
+        /// Some apps may contain tags. It's your responsiblity to parse it. 
+        /// This property can be null when not applicable.
+        /// </summary>
+        public JArray Tags { get; set; }
+
+        [Obsolete("Use AppData instead.")]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [JsonIgnore]
+        public Dictionary<string, string> app_data => AppData;
+        [JsonIgnore]
+        public Dictionary<string, string> AppData { get; set; }
+
+        public void debug_app_data()
+        {
+            Console.WriteLine("\n\"" + Name + "\"");
+            if (AppData == null)
+            {
+                Console.WriteLine("Doesn't have app_data");
+                return;
+            }
+
+            foreach (var value in AppData)
+            {
+                Console.WriteLine(string.Format("{0} = {1}", value.Key, value.Value));
+            }
+            Console.WriteLine("");
         }
     }
 }


### PR DESCRIPTION
A more flexible and easy to use implementation of GenericInventory. Also fixes #640 

 Instruction to code reviewers.

1. Refactored methods to it's new name.
    -SteamTradeDemoHandler.cs 
2. Unit test
   -SteamBotUnitTest/SteamTrade/GenericInventoryTest.cs
3. Upgrade unit test project to use NUnit 3
   -SteamBotUnitTest/SteamTradeUnitTest.csproj
   -SteamBotUnitTest/packages.config
4. Main changes.
   -SteamTrade/GenericInventory.cs


There are almost no breaking changes to GenericInventory. Except for ItemDescription class. To enable extensibility using generic, I had to move it from nested class to the parent namespace.

Other changes include
1. refactoring to comply with Microsoft's naming convention as per CONTRIBUTING.md. This should be the only breaking change.
2. Fill the properties in ItemDescription using serialization instead of direct assignments.
3. Added retry when downloading JSON. Reason is explained in XML documentation.
4. Added LoadAsync()