### PR TITLE
Extract interface for Log and allow users to disable logging

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -153,7 +153,7 @@ namespace SteamBot
                 Username = config.Username,
                 Password = config.Password
             };
-            DisplayName  = config.DisplayName;
+            DisplayName = config.DisplayName;
             ChatResponse = config.ChatResponse;
             MaximumTradeTime = config.MaximumTradeTime;
             MaximumActionGap = config.MaximumActionGap;
@@ -166,7 +166,7 @@ namespace SteamBot
             isProccess = process;
             try
             {
-                if( config.LogLevel != null )
+                if (config.LogLevel != null)
                 {
                     consoleLogLevel = (Log.LogLevel)Enum.Parse(typeof(Log.LogLevel), config.LogLevel, true);
                     Console.WriteLine(@"(Console) LogLevel configuration parameter used in bot {0} is depreciated and may be removed in future versions. Please use ConsoleLogLevel instead.", DisplayName);
@@ -190,8 +190,7 @@ namespace SteamBot
             }
 
             logFile = config.LogFile;
-            if (!string.IsNullOrEmpty(logFile))
-                Log = new Log(logFile, DisplayName, consoleLogLevel, fileLogLevel);
+            Log = new Log(logFile, DisplayName, consoleLogLevel, fileLogLevel);
             createHandler = handlerCreator;
             BotControlClass = config.BotControlClass;
             SteamWeb = new SteamWeb();
@@ -199,7 +198,7 @@ namespace SteamBot
             // Hacking around https
             ServicePointManager.ServerCertificateValidationCallback += SteamWeb.ValidateRemoteCertificate;
 
-            Log.Debug ("Initializing Steam Bot...");            
+            Log.Debug("Initializing Steam Bot...");
             SteamClient = new SteamClient();
             SteamClient.AddHandler(new SteamNotifications());
             SteamTrade = SteamClient.GetHandler<SteamTrading>();
@@ -276,7 +275,7 @@ namespace SteamBot
         /// <c>true</c>, if trade was opened,
         /// <c>false</c> if there is another trade that must be closed first.
         /// </returns>
-        public bool OpenTrade (SteamID other)
+        public bool OpenTrade(SteamID other)
         {
             if (CurrentTrade != null || CheckCookies() == false)
                 return false;
@@ -287,16 +286,16 @@ namespace SteamBot
         /// <summary>
         /// Closes the current active trade.
         /// </summary>
-        public void CloseTrade() 
+        public void CloseTrade()
         {
             if (CurrentTrade == null)
                 return;
-            UnsubscribeTrade (GetUserHandler (CurrentTrade.OtherSID), CurrentTrade);
-            tradeManager.StopTrade ();
+            UnsubscribeTrade(GetUserHandler(CurrentTrade.OtherSID), CurrentTrade);
+            tradeManager.StopTrade();
             CurrentTrade = null;
         }
 
-        void OnTradeTimeout(object sender, EventArgs args) 
+        void OnTradeTimeout(object sender, EventArgs args)
         {
             // ignore event params and just null out the trade.
             GetUserHandler(CurrentTrade.OtherSID).OnTradeTimeout();
@@ -404,7 +403,7 @@ namespace SteamBot
                     Log.Error("Error while polling trade offers: " + e);
                 }
 
-                Thread.Sleep(tradeOfferPollingIntervalSecs*1000);
+                Thread.Sleep(tradeOfferPollingIntervalSecs * 1000);
             }
         }
 
@@ -426,7 +425,7 @@ namespace SteamBot
             }
         }
 
-        bool HandleTradeSessionStart (SteamID other)
+        bool HandleTradeSessionStart(SteamID other)
         {
             if (CurrentTrade != null)
                 return false;
@@ -480,93 +479,93 @@ namespace SteamBot
         {
             Log.Debug(msg.ToString());
             #region Login
-            msg.Handle<SteamClient.ConnectedCallback> (callback =>
-            {
-                Log.Debug ("Connection Callback: {0}", callback.Result);
+            msg.Handle<SteamClient.ConnectedCallback>(callback =>
+           {
+               Log.Debug("Connection Callback: {0}", callback.Result);
 
-                if (callback.Result == EResult.OK)
-                {
-                    UserLogOn();
-                }
-                else
-                {
-                    Log.Error ("Failed to connect to Steam Community, trying again...");
-                    SteamClient.Connect ();
-                }
+               if (callback.Result == EResult.OK)
+               {
+                   UserLogOn();
+               }
+               else
+               {
+                   Log.Error("Failed to connect to Steam Community, trying again...");
+                   SteamClient.Connect();
+               }
 
-            });
+           });
 
-            msg.Handle<SteamUser.LoggedOnCallback> (callback =>
-            {
-                Log.Debug("Logged On Callback: {0}", callback.Result);
+            msg.Handle<SteamUser.LoggedOnCallback>(callback =>
+           {
+               Log.Debug("Logged On Callback: {0}", callback.Result);
 
-                if (callback.Result == EResult.OK)
-                {
-                    myUserNonce = callback.WebAPIUserNonce;
-                }
-                else
-                {
-                    Log.Error("Login Error: {0}", callback.Result);
-                }
+               if (callback.Result == EResult.OK)
+               {
+                   myUserNonce = callback.WebAPIUserNonce;
+               }
+               else
+               {
+                   Log.Error("Login Error: {0}", callback.Result);
+               }
 
-                if (callback.Result == EResult.AccountLogonDeniedNeedTwoFactorCode)
-                {
-                    var mobileAuthCode = GetMobileAuthCode();
-                    if (string.IsNullOrEmpty(mobileAuthCode))
-                    {
-                        Log.Error("Failed to generate 2FA code. Make sure you have linked the authenticator via SteamBot.");
-                    }
-                    else
-                    {
-                        logOnDetails.TwoFactorCode = mobileAuthCode;
-                        Log.Success("Generated 2FA code.");
-                    }
-                }
-                else if (callback.Result == EResult.TwoFactorCodeMismatch)
-                {
-                    SteamAuth.TimeAligner.AlignTime();
-                    logOnDetails.TwoFactorCode = SteamGuardAccount.GenerateSteamGuardCode();
-                    Log.Success("Regenerated 2FA code.");
-                }
-                else if (callback.Result == EResult.AccountLogonDenied)
-                {
-                    Log.Interface ("This account is SteamGuard enabled. Enter the code via the `auth' command.");
+               if (callback.Result == EResult.AccountLogonDeniedNeedTwoFactorCode)
+               {
+                   var mobileAuthCode = GetMobileAuthCode();
+                   if (string.IsNullOrEmpty(mobileAuthCode))
+                   {
+                       Log.Error("Failed to generate 2FA code. Make sure you have linked the authenticator via SteamBot.");
+                   }
+                   else
+                   {
+                       logOnDetails.TwoFactorCode = mobileAuthCode;
+                       Log.Success("Generated 2FA code.");
+                   }
+               }
+               else if (callback.Result == EResult.TwoFactorCodeMismatch)
+               {
+                   SteamAuth.TimeAligner.AlignTime();
+                   logOnDetails.TwoFactorCode = SteamGuardAccount.GenerateSteamGuardCode();
+                   Log.Success("Regenerated 2FA code.");
+               }
+               else if (callback.Result == EResult.AccountLogonDenied)
+               {
+                   Log.Interface("This account is SteamGuard enabled. Enter the code via the `auth' command.");
 
                     // try to get the steamguard auth code from the event callback
                     var eva = new SteamGuardRequiredEventArgs();
-                    FireOnSteamGuardRequired(eva);
-                    if (!String.IsNullOrEmpty(eva.SteamGuard))
-                        logOnDetails.AuthCode = eva.SteamGuard;
-                    else
-                        logOnDetails.AuthCode = Console.ReadLine();
-                }
-                else if (callback.Result == EResult.InvalidLoginAuthCode)
-                {
-                    Log.Interface("The given SteamGuard code was invalid. Try again using the `auth' command.");
-                    logOnDetails.AuthCode = Console.ReadLine();
-                }
-            });
+                   FireOnSteamGuardRequired(eva);
+                   if (!String.IsNullOrEmpty(eva.SteamGuard))
+                       logOnDetails.AuthCode = eva.SteamGuard;
+                   else
+                       logOnDetails.AuthCode = Console.ReadLine();
+               }
+               else if (callback.Result == EResult.InvalidLoginAuthCode)
+               {
+                   Log.Interface("The given SteamGuard code was invalid. Try again using the `auth' command.");
+                   logOnDetails.AuthCode = Console.ReadLine();
+               }
+           });
 
-            msg.Handle<SteamUser.LoginKeyCallback> (callback =>
-            {
-                myUniqueId = callback.UniqueID.ToString();
+            msg.Handle<SteamUser.LoginKeyCallback>(callback =>
+           {
+               myUniqueId = callback.UniqueID.ToString();
 
-                UserWebLogOn();
+               UserWebLogOn();
 
-                if (Trade.CurrentSchema == null)
-                {
-                    Log.Info ("Downloading Schema...");
-                    Trade.CurrentSchema = Schema.FetchSchema (ApiKey, schemaLang);
-                    Log.Success ("Schema Downloaded!");
-                }
+               if (Trade.CurrentSchema == null)
+               {
+                   Log.Info("Downloading Schema...");
+                   Trade.CurrentSchema = Schema.FetchSchema(ApiKey, schemaLang);
+                   Log.Success("Schema Downloaded!");
+               }
 
-                SteamFriends.SetPersonaName (DisplayNamePrefix+DisplayName);
-                SteamFriends.SetPersonaState (EPersonaState.Online);
+               SteamFriends.SetPersonaName(DisplayNamePrefix + DisplayName);
+               SteamFriends.SetPersonaState(EPersonaState.Online);
 
-                Log.Success ("Steam Bot Logged In Completely!");
+               Log.Success("Steam Bot Logged In Completely!");
 
-                GetUserHandler(SteamClient.SteamID).OnLoginCompleted();
-            });
+               GetUserHandler(SteamClient.SteamID).OnLoginCompleted();
+           });
 
             msg.Handle<SteamUser.WebAPIUserNonceCallback>(webCallback =>
             {
@@ -628,7 +627,7 @@ namespace SteamBot
                                 }
                                 else
                                 {
-                                    if(friends.Contains(friend.SteamID))
+                                    if (friends.Contains(friend.SteamID))
                                     {
                                         friends.Remove(friend.SteamID);
                                     }
@@ -642,19 +641,19 @@ namespace SteamBot
             });
 
 
-            msg.Handle<SteamFriends.FriendMsgCallback> (callback =>
-            {
-                EChatEntryType type = callback.EntryType;
+            msg.Handle<SteamFriends.FriendMsgCallback>(callback =>
+           {
+               EChatEntryType type = callback.EntryType;
 
-                if (callback.EntryType == EChatEntryType.ChatMsg)
-                {
-                    Log.Info ("Chat Message from {0}: {1}",
-                                         SteamFriends.GetFriendPersonaName (callback.Sender),
-                                         callback.Message
-                                         );
-                    GetUserHandler(callback.Sender).OnMessageHandler(callback.Message, type);
-                }
-            });
+               if (callback.EntryType == EChatEntryType.ChatMsg)
+               {
+                   Log.Info("Chat Message from {0}: {1}",
+                                        SteamFriends.GetFriendPersonaName(callback.Sender),
+                                        callback.Message
+                                        );
+                   GetUserHandler(callback.Sender).OnMessageHandler(callback.Message, type);
+               }
+           });
             #endregion
 
             #region Group Chat
@@ -665,46 +664,46 @@ namespace SteamBot
             #endregion
 
             #region Trading
-            msg.Handle<SteamTrading.SessionStartCallback> (callback =>
-            {
-                bool started = HandleTradeSessionStart (callback.OtherClient);
+            msg.Handle<SteamTrading.SessionStartCallback>(callback =>
+           {
+               bool started = HandleTradeSessionStart(callback.OtherClient);
 
-                if (!started)
-                    Log.Error ("Could not start the trade session.");
-                else
-                    Log.Debug ("SteamTrading.SessionStartCallback handled successfully. Trade Opened.");
-            });
+               if (!started)
+                   Log.Error("Could not start the trade session.");
+               else
+                   Log.Debug("SteamTrading.SessionStartCallback handled successfully. Trade Opened.");
+           });
 
-            msg.Handle<SteamTrading.TradeProposedCallback> (callback =>
-            {
-                if (CheckCookies() == false)
-                {
-                    SteamTrade.RespondToTrade(callback.TradeID, false);
-                    return;
-                }
+            msg.Handle<SteamTrading.TradeProposedCallback>(callback =>
+           {
+               if (CheckCookies() == false)
+               {
+                   SteamTrade.RespondToTrade(callback.TradeID, false);
+                   return;
+               }
 
-                try
-                {
-                    tradeManager.InitializeTrade(SteamUser.SteamID, callback.OtherClient);
-                }
-                catch (WebException we)
-                {                 
-                    SteamFriends.SendChatMessage(callback.OtherClient,
-                             EChatEntryType.ChatMsg,
-                             "Trade error: " + we.Message);
+               try
+               {
+                   tradeManager.InitializeTrade(SteamUser.SteamID, callback.OtherClient);
+               }
+               catch (WebException we)
+               {
+                   SteamFriends.SendChatMessage(callback.OtherClient,
+                            EChatEntryType.ChatMsg,
+                            "Trade error: " + we.Message);
 
-                    SteamTrade.RespondToTrade(callback.TradeID, false);
-                    return;
-                }
-                catch (Exception)
-                {
-                    SteamFriends.SendChatMessage(callback.OtherClient,
-                             EChatEntryType.ChatMsg,
-                             "Trade declined. Could not correctly fetch your backpack.");
+                   SteamTrade.RespondToTrade(callback.TradeID, false);
+                   return;
+               }
+               catch (Exception)
+               {
+                   SteamFriends.SendChatMessage(callback.OtherClient,
+                            EChatEntryType.ChatMsg,
+                            "Trade declined. Could not correctly fetch your backpack.");
 
-                    SteamTrade.RespondToTrade(callback.TradeID, false);
-                    return;
-                }
+                   SteamTrade.RespondToTrade(callback.TradeID, false);
+                   return;
+               }
 
                 //if (tradeManager.OtherInventory.IsPrivate)
                 //{
@@ -716,50 +715,50 @@ namespace SteamBot
                 //    return;
                 //}
 
-                if (CurrentTrade == null && GetUserHandler (callback.OtherClient).OnTradeRequest ())
-                    SteamTrade.RespondToTrade (callback.TradeID, true);
-                else
-                    SteamTrade.RespondToTrade (callback.TradeID, false);
-            });
+                if (CurrentTrade == null && GetUserHandler(callback.OtherClient).OnTradeRequest())
+                   SteamTrade.RespondToTrade(callback.TradeID, true);
+               else
+                   SteamTrade.RespondToTrade(callback.TradeID, false);
+           });
 
-            msg.Handle<SteamTrading.TradeResultCallback> (callback =>
-            {
-                if (callback.Response == EEconTradeResponse.Accepted)
-                {
-                    Log.Debug("Trade Status: {0}", callback.Response);
-                    Log.Info ("Trade Accepted!");
-                    GetUserHandler(callback.OtherClient).OnTradeRequestReply(true, callback.Response.ToString());
-                }
-                else
-                {
-                    Log.Warn("Trade failed: {0}", callback.Response);
-                    CloseTrade ();
-                    GetUserHandler(callback.OtherClient).OnTradeRequestReply(false, callback.Response.ToString());
-                }
+            msg.Handle<SteamTrading.TradeResultCallback>(callback =>
+           {
+               if (callback.Response == EEconTradeResponse.Accepted)
+               {
+                   Log.Debug("Trade Status: {0}", callback.Response);
+                   Log.Info("Trade Accepted!");
+                   GetUserHandler(callback.OtherClient).OnTradeRequestReply(true, callback.Response.ToString());
+               }
+               else
+               {
+                   Log.Warn("Trade failed: {0}", callback.Response);
+                   CloseTrade();
+                   GetUserHandler(callback.OtherClient).OnTradeRequestReply(false, callback.Response.ToString());
+               }
 
-            });
+           });
             #endregion
 
             #region Disconnect
-            msg.Handle<SteamUser.LoggedOffCallback> (callback =>
-            {
-                IsLoggedIn = false;
-                Log.Warn("Logged off Steam.  Reason: {0}", callback.Result);
-                CancelTradeOfferPollingThread();
-            });
+            msg.Handle<SteamUser.LoggedOffCallback>(callback =>
+           {
+               IsLoggedIn = false;
+               Log.Warn("Logged off Steam.  Reason: {0}", callback.Result);
+               CancelTradeOfferPollingThread();
+           });
 
-            msg.Handle<SteamClient.DisconnectedCallback> (callback =>
-            {
-                if(IsLoggedIn)
-                {
-                    IsLoggedIn = false;
-                    CloseTrade();
-                    Log.Warn("Disconnected from Steam Network!");
-                    CancelTradeOfferPollingThread();
-                }
+            msg.Handle<SteamClient.DisconnectedCallback>(callback =>
+           {
+               if (IsLoggedIn)
+               {
+                   IsLoggedIn = false;
+                   CloseTrade();
+                   Log.Warn("Disconnected from Steam Network!");
+                   CancelTradeOfferPollingThread();
+               }
 
-                SteamClient.Connect ();
-            });
+               SteamClient.Connect();
+           });
             #endregion
 
             #region Notifications
@@ -846,7 +845,7 @@ namespace SteamBot
                         catch (IOException)
                         {
                             Log.Error("Failed to save auth file. Aborting authentication.");
-                        }                        
+                        }
                     }
                     else
                     {
@@ -872,7 +871,7 @@ namespace SteamBot
             // get sentry file which has the machine hw info saved 
             // from when a steam guard code was entered
             Directory.CreateDirectory(System.IO.Path.Combine(System.Windows.Forms.Application.StartupPath, "sentryfiles"));
-            FileInfo fi = new FileInfo(System.IO.Path.Combine("sentryfiles",String.Format("{0}.sentryfile", logOnDetails.Username)));
+            FileInfo fi = new FileInfo(System.IO.Path.Combine("sentryfiles", String.Format("{0}.sentryfile", logOnDetails.Username)));
 
             if (fi.Exists && fi.Length > 0)
                 logOnDetails.SentryFileHash = SHAHash(File.ReadAllBytes(fi.FullName));
@@ -888,12 +887,12 @@ namespace SteamBot
             {
                 IsLoggedIn = SteamWeb.Authenticate(myUniqueId, SteamClient, myUserNonce);
 
-                if(!IsLoggedIn)
+                if (!IsLoggedIn)
                 {
                     Log.Warn("Authentication failed, retrying in 2s...");
                     Thread.Sleep(2000);
                 }
-            } while(!IsLoggedIn);
+            } while (!IsLoggedIn);
 
             Log.Success("User Authenticated!");
 
@@ -952,43 +951,43 @@ namespace SteamBot
                 userHandlers.Remove(sid);
         }
 
-        static byte [] SHAHash (byte[] input)
+        static byte[] SHAHash(byte[] input)
         {
             SHA1Managed sha = new SHA1Managed();
-            
-            byte[] output = sha.ComputeHash( input );
-            
+
+            byte[] output = sha.ComputeHash(input);
+
             sha.Clear();
-            
+
             return output;
         }
 
         void OnUpdateMachineAuthCallback(SteamUser.UpdateMachineAuthCallback machineAuth)
         {
-            byte[] hash = SHAHash (machineAuth.Data);
+            byte[] hash = SHAHash(machineAuth.Data);
 
             Directory.CreateDirectory(System.IO.Path.Combine(System.Windows.Forms.Application.StartupPath, "sentryfiles"));
 
-            File.WriteAllBytes (System.IO.Path.Combine("sentryfiles", String.Format("{0}.sentryfile", logOnDetails.Username)), machineAuth.Data);
-            
+            File.WriteAllBytes(System.IO.Path.Combine("sentryfiles", String.Format("{0}.sentryfile", logOnDetails.Username)), machineAuth.Data);
+
             var authResponse = new SteamUser.MachineAuthDetails
             {
                 BytesWritten = machineAuth.BytesToWrite,
                 FileName = machineAuth.FileName,
                 FileSize = machineAuth.BytesToWrite,
                 Offset = machineAuth.Offset,
-                
+
                 SentryFileHash = hash, // should be the sha1 hash of the sentry file we just wrote
-                
+
                 OneTimePassword = machineAuth.OneTimePassword, // not sure on this one yet, since we've had no examples of steam using OTPs
-                
+
                 LastError = 0, // result from win32 GetLastError
                 Result = EResult.OK, // if everything went okay, otherwise ~who knows~
                 JobID = machineAuth.JobID, // so we respond to the correct server job
             };
-            
+
             // send off our response
-            SteamUser.SendMachineAuthResponse (authResponse);
+            SteamUser.SendMachineAuthResponse(authResponse);
         }
 
         /// <summary>
@@ -1008,7 +1007,7 @@ namespace SteamBot
         /// </example>
         public void GetInventory()
         {
-            myInventoryTask = Task.Factory.StartNew((Func<Inventory>) FetchBotsInventory);
+            myInventoryTask = Task.Factory.StartNew((Func<Inventory>)FetchBotsInventory);
         }
 
         public void TradeOfferRouter(TradeOffer offer)
@@ -1029,7 +1028,7 @@ namespace SteamBot
         /// <summary>
         /// Subscribes all listeners of this to the trade.
         /// </summary>
-        public void SubscribeTrade (Trade trade, UserHandler handler)
+        public void SubscribeTrade(Trade trade, UserHandler handler)
         {
             trade.OnAwaitingConfirmation += handler._OnTradeAwaitingConfirmation;
             trade.OnClose += handler.OnTradeClose;
@@ -1043,11 +1042,11 @@ namespace SteamBot
             trade.OnUserSetReady += handler.OnTradeReadyHandler;
             trade.OnUserAccept += handler.OnTradeAcceptHandler;
         }
-        
+
         /// <summary>
         /// Unsubscribes all listeners of this from the current trade.
         /// </summary>
-        public void UnsubscribeTrade (UserHandler handler, Trade trade)
+        public void UnsubscribeTrade(UserHandler handler, Trade trade)
         {
             trade.OnAwaitingConfirmation -= handler._OnTradeAwaitingConfirmation;
             trade.OnClose -= handler.OnTradeClose;
@@ -1068,7 +1067,7 @@ namespace SteamBot
         private Inventory FetchBotsInventory()
         {
             var inventory = Inventory.FetchInventory(SteamUser.SteamID, ApiKey, SteamWeb);
-            if(inventory.IsPrivate)
+            if (inventory.IsPrivate)
             {
                 Log.Warn("The bot's backpack is private! If your bot adds any items it will fail! Your bot's backpack should be Public.");
             }
@@ -1099,7 +1098,7 @@ namespace SteamBot
                 {
                     Log.Error("Invalid session when trying to fetch trade confirmations.");
                 }
-            }                        
+            }
         }
 
         /// <summary>
@@ -1120,7 +1119,7 @@ namespace SteamBot
             if (!string.IsNullOrEmpty(token))
             {
                 data.Add("token", token);
-            }            
+            }
 
             var resp = SteamWeb.Fetch(url, "GET", data, false);
             if (string.IsNullOrWhiteSpace(resp))
@@ -1222,7 +1221,7 @@ namespace SteamBot
                         HandleSteamMessage(msg);
                     }
 
-                    if(tradeOfferManager != null)
+                    if (tradeOfferManager != null)
                     {
                         tradeOfferManager.HandleNextPendingTradeOfferUpdate();
                     }
@@ -1280,7 +1279,7 @@ namespace SteamBot
             AcceptInvite.Body.AcceptInvite = true;
 
             this.SteamClient.Send(AcceptInvite);
-            
+
         }
 
         /// <summary>

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -91,10 +91,6 @@ namespace SteamBot
         /// The prefix shown before bot's display name.
         /// </summary>
         public readonly string DisplayNamePrefix;
-        /// <summary>
-        /// The instance of the Logger for the bot.
-        /// </summary>
-        public readonly Log Log;
         #endregion
 
         #region Public variables
@@ -116,6 +112,11 @@ namespace SteamBot
         /// Default: 0 = No game.
         /// </summary>
         public int CurrentGame { get; private set; }
+
+        /// <summary>
+        /// The instance of the Logger for the bot. You may change it while running.
+        /// </summary>
+        public ILog Log { get; set; }
 
         public SteamAuth.SteamGuardAccount SteamGuardAccount;
         #endregion
@@ -142,7 +143,7 @@ namespace SteamBot
         /// Compatibility sanity.
         /// </summary>
         [Obsolete("Refactored to be Log instead of log")]
-        public Log log { get { return Log; } }
+        public ILog log { get { return Log; } }
 
         public Bot(Configuration.BotInfo config, string apiKey, UserHandlerCreator handlerCreator, bool debug = false, bool process = false)
         {
@@ -175,7 +176,7 @@ namespace SteamBot
             catch (ArgumentException)
             {
                 Console.WriteLine(@"(Console) ConsoleLogLevel invalid or unspecified for bot {0}. Defaulting to ""Info""", DisplayName);
-                consoleLogLevel = Log.LogLevel.Info;
+                consoleLogLevel = SteamBot.Log.LogLevel.Info;
             }
 
             try
@@ -185,11 +186,12 @@ namespace SteamBot
             catch (ArgumentException)
             {
                 Console.WriteLine(@"(Console) FileLogLevel invalid or unspecified for bot {0}. Defaulting to ""Info""", DisplayName);
-                fileLogLevel = Log.LogLevel.Info;
+                fileLogLevel = SteamBot.Log.LogLevel.Info;
             }
 
             logFile = config.LogFile;
-            Log = new Log(logFile, DisplayName, consoleLogLevel, fileLogLevel);
+            if (!string.IsNullOrEmpty(logFile))
+                Log = new Log(logFile, DisplayName, consoleLogLevel, fileLogLevel);
             createHandler = handlerCreator;
             BotControlClass = config.BotControlClass;
             SteamWeb = new SteamWeb();

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -152,6 +152,9 @@ namespace SteamBot
             public string ApiKey { get; set; }
             public string DisplayName { get; set; }
             public string ChatResponse { get; set; }
+            /// <summary>
+            /// If this is null or empty, no log file will be written.
+            /// </summary>
             public string LogFile { get; set; }
             public string BotControlClass { get; set; }
             public int MaximumTradeTime { get; set; }

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ILog.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="SteamGroups\CMsgInviteUserToGroup.cs" />
     <Compile Include="SteamTradeDemoHandler.cs" />

--- a/SteamBot/ILog.cs
+++ b/SteamBot/ILog.cs
@@ -1,0 +1,14 @@
+﻿namespace SteamBot
+{
+    public interface ILog : System.IDisposable
+    {
+        bool ShowBotName { get; set; }
+
+        void Debug(string data, params object[] formatParams);
+        void Error(string data, params object[] formatParams);
+        void Info(string data, params object[] formatParams);
+        void Interface(string data, params object[] formatParams);
+        void Success(string data, params object[] formatParams);
+        void Warn(string data, params object[] formatParams);
+    }
+}

--- a/SteamBot/Log.cs
+++ b/SteamBot/Log.cs
@@ -32,8 +32,11 @@ namespace SteamBot
         public Log(string logFile, string botName = "", LogLevel consoleLogLevel = LogLevel.Info, LogLevel fileLogLevel = LogLevel.Info)
         {
             Directory.CreateDirectory(Path.Combine(System.Windows.Forms.Application.StartupPath, "logs"));
-            _FileStream = File.AppendText (Path.Combine("logs",logFile));
-            _FileStream.AutoFlush = true;
+            if (!string.IsNullOrEmpty(logFile))
+            {
+                _FileStream = File.AppendText(Path.Combine("logs", logFile));
+                _FileStream.AutoFlush = true;
+            }
             _botName = botName;
             OutputLevel = consoleLogLevel;
             FileLogLevel = fileLogLevel;
@@ -99,7 +102,7 @@ namespace SteamBot
 
             if(level >= FileLogLevel)
             {
-                _FileStream.WriteLine(formattedString);
+                _FileStream?.WriteLine(formattedString);
             }
             if(level >= OutputLevel)
             {
@@ -180,7 +183,7 @@ namespace SteamBot
             if (disposed)
                 return;
             if (disposing)
-                _FileStream.Dispose();
+                _FileStream?.Dispose();
             disposed = true;
         }
 

--- a/SteamBot/Log.cs
+++ b/SteamBot/Log.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace SteamBot
 {
-    public class Log : IDisposable
+    public class Log : ILog
     {
         public enum LogLevel
         {

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -98,7 +98,7 @@ namespace SteamBot
         /// <summary>
         /// Gets the log the bot uses for convenience.
         /// </summary>
-        public Log Log
+        public ILog Log
         {
             get { return Bot.Log; }
         }


### PR DESCRIPTION
1. In Bot.cs, allow consumers to change the instance of log while bot running.
2. When Configuration.BotInfo.LogFile is null or empty, disable file logging.
3. Extract interface for Log to allow the creation of other kinds of logging. This is especially useful when using the bot in a GUI application.