### PR TITLE
Extract interface for Log and allow users to disable file logging

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -91,10 +91,6 @@ namespace SteamBot
         /// The prefix shown before bot's display name.
         /// </summary>
         public readonly string DisplayNamePrefix;
-        /// <summary>
-        /// The instance of the Logger for the bot.
-        /// </summary>
-        public readonly Log Log;
         #endregion
 
         #region Public variables
@@ -116,6 +112,11 @@ namespace SteamBot
         /// Default: 0 = No game.
         /// </summary>
         public int CurrentGame { get; private set; }
+
+        /// <summary>
+        /// The instance of the Logger for the bot. You may change it while bot is running.
+        /// </summary>
+        public ILog Log { get; set; }
 
         public SteamAuth.SteamGuardAccount SteamGuardAccount;
         #endregion
@@ -142,7 +143,7 @@ namespace SteamBot
         /// Compatibility sanity.
         /// </summary>
         [Obsolete("Refactored to be Log instead of log")]
-        public Log log { get { return Log; } }
+        public ILog log { get { return Log; } }
 
         public Bot(Configuration.BotInfo config, string apiKey, UserHandlerCreator handlerCreator, bool debug = false, bool process = false)
         {
@@ -175,7 +176,7 @@ namespace SteamBot
             catch (ArgumentException)
             {
                 Console.WriteLine(@"(Console) ConsoleLogLevel invalid or unspecified for bot {0}. Defaulting to ""Info""", DisplayName);
-                consoleLogLevel = Log.LogLevel.Info;
+                consoleLogLevel = SteamBot.Log.LogLevel.Info;
             }
 
             try
@@ -185,7 +186,7 @@ namespace SteamBot
             catch (ArgumentException)
             {
                 Console.WriteLine(@"(Console) FileLogLevel invalid or unspecified for bot {0}. Defaulting to ""Info""", DisplayName);
-                fileLogLevel = Log.LogLevel.Info;
+                fileLogLevel = SteamBot.Log.LogLevel.Info;
             }
 
             logFile = config.LogFile;

--- a/SteamBot/Configuration.cs
+++ b/SteamBot/Configuration.cs
@@ -152,6 +152,9 @@ namespace SteamBot
             public string ApiKey { get; set; }
             public string DisplayName { get; set; }
             public string ChatResponse { get; set; }
+            /// <summary>
+            /// If this is null or empty, no log file will be written.
+            /// </summary>
             public string LogFile { get; set; }
             public string BotControlClass { get; set; }
             public int MaximumTradeTime { get; set; }

--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -72,6 +72,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ILog.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="SteamGroups\CMsgInviteUserToGroup.cs" />
     <Compile Include="SteamTradeDemoHandler.cs" />

--- a/SteamBot/ILog.cs
+++ b/SteamBot/ILog.cs
@@ -1,0 +1,14 @@
+﻿namespace SteamBot
+{
+    public interface ILog : System.IDisposable
+    {
+        bool ShowBotName { get; set; }
+
+        void Debug(string data, params object[] formatParams);
+        void Error(string data, params object[] formatParams);
+        void Info(string data, params object[] formatParams);
+        void Interface(string data, params object[] formatParams);
+        void Success(string data, params object[] formatParams);
+        void Warn(string data, params object[] formatParams);
+    }
+}

--- a/SteamBot/Log.cs
+++ b/SteamBot/Log.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 namespace SteamBot
 {
-    public class Log : IDisposable
+    public class Log : ILog
     {
         public enum LogLevel
         {
@@ -32,8 +32,11 @@ namespace SteamBot
         public Log(string logFile, string botName = "", LogLevel consoleLogLevel = LogLevel.Info, LogLevel fileLogLevel = LogLevel.Info)
         {
             Directory.CreateDirectory(Path.Combine(System.Windows.Forms.Application.StartupPath, "logs"));
-            _FileStream = File.AppendText (Path.Combine("logs",logFile));
-            _FileStream.AutoFlush = true;
+            if (!string.IsNullOrEmpty(logFile))
+            {
+                _FileStream = File.AppendText(Path.Combine("logs", logFile));
+                _FileStream.AutoFlush = true;
+            }
             _botName = botName;
             OutputLevel = consoleLogLevel;
             FileLogLevel = fileLogLevel;
@@ -99,7 +102,7 @@ namespace SteamBot
 
             if(level >= FileLogLevel)
             {
-                _FileStream.WriteLine(formattedString);
+                _FileStream?.WriteLine(formattedString);
             }
             if(level >= OutputLevel)
             {
@@ -180,7 +183,7 @@ namespace SteamBot
             if (disposed)
                 return;
             if (disposing)
-                _FileStream.Dispose();
+                _FileStream?.Dispose();
             disposed = true;
         }
 

--- a/SteamBot/UserHandler.cs
+++ b/SteamBot/UserHandler.cs
@@ -98,7 +98,7 @@ namespace SteamBot
         /// <summary>
         /// Gets the log the bot uses for convenience.
         /// </summary>
-        public Log Log
+        public ILog Log
         {
             get { return Bot.Log; }
         }


### PR DESCRIPTION
1. In Bot.cs, allow consumers to change the instance of log while bot running.
2. When Configuration.BotInfo.LogFile is null or empty, disable file logging.
3. Extract interface for Log to allow the creation of other kinds of logging. This is especially useful when using the bot in a GUI application.