### PR TITLE
Disable C# 6 in project

### DIFF
--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -25,6 +25,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <Externalconsole>True</Externalconsole>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/SteamTrade/SteamTrade.csproj
+++ b/SteamTrade/SteamTrade.csproj
@@ -24,6 +24,7 @@
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
     <Prefer32Bit>false</Prefer32Bit>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>


### PR DESCRIPTION
If we don't want to use C# 6 as per #1002, disable it.
