### PR TITLE
Fixed dispose pattern

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -1319,7 +1319,8 @@ namespace SteamBot
             if (disposing)
             {
                 StopBot();
-                Log?.Dispose();
+                if (Log != null)
+                    Log?.Dispose();
             }
         }
     }

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -1320,7 +1320,7 @@ namespace SteamBot
             {
                 StopBot();
                 if (Log != null)
-                    Log?.Dispose();
+                    Log.Dispose();
             }
         }
     }

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -211,11 +211,6 @@ namespace SteamBot
             botThread.RunWorkerCompleted += BackgroundWorkerOnRunWorkerCompleted;
         }
 
-        ~Bot()
-        {
-            Dispose(false);
-        }
-
         private void CreateFriendsListIfNecessary()
         {
             if (friends != null)
@@ -1312,21 +1307,20 @@ namespace SteamBot
         }
 
         #endregion
-
+        
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            if (disposed)
-                return;
-            StopBot();
             if (disposing)
-                Log.Dispose();
-            disposed = true;
+            {
+                StopBot();
+                Log?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
**Before**
The application may crash when GC calls Bot's finalizer. And then the finalizer call Dispose(false) where StopBot() is called. StopBot() accesses fields that may well been finalized, thus NullReferenceException is thrown.

**After**
Removed Bot's finalizer since it doesn't hold any unmanaged resource. 
Implemented a basic dispose patter where StopBot() and Log.Dispose() is called only when disposing (not finalizing)

For more info regarding Dispose Pattern, see
https://msdn.microsoft.com/en-us/library/b1yfkh5e(v=vs.110).aspx