### PR TITLE
 add get_descriptions parameter to gettradeoffer request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ packages
 
 # Allow NuGet specific exes and dlls
 !.nuget/Microsoft.Build.dll
-/.vs/SteamBot/v15/Server/sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ packages
 
 # Allow NuGet specific exes and dlls
 !.nuget/Microsoft.Build.dll
+/.vs/SteamBot/v15/Server/sqlite3

--- a/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
+++ b/SteamTrade/TradeOffer/TradeOfferWebAPI.cs
@@ -26,7 +26,7 @@ namespace SteamTrade.TradeOffer
 
         public OfferResponse GetTradeOffer(string tradeofferid)
         {
-            string options = string.Format("?key={0}&tradeofferid={1}&language={2}", apiKey, tradeofferid, "en_us");
+            string options = string.Format("?key={0}&tradeofferid={1}&language={2}&get_descriptions=1", apiKey, tradeofferid, "en_us");
             string url = String.Format(BaseUrl, "GetTradeOffer", "v1", options);
             try
             {


### PR DESCRIPTION
PR for issue: Trade Offer Item descriptions not getting loaded in TradeOfferWebAPI.cs #1100