### PR TITLE
Update the SteamAuth package to the latest NuGet Version

### DIFF
--- a/SteamBot/ExampleBot.csproj
+++ b/SteamBot/ExampleBot.csproj
@@ -47,8 +47,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="SteamAuth, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SteamAuth.1.1.0\lib\net45\SteamAuth.dll</HintPath>
+    <Reference Include="SteamAuth, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SteamAuth.2.0.0\lib\net45\SteamAuth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SteamKit2, Version=1.8.1.0, Culture=neutral, PublicKeyToken=ed3ce47ed5aad940, processorArchitecture=MSIL">

--- a/SteamBot/packages.config
+++ b/SteamBot/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net451" />
-  <package id="SteamAuth" version="1.1.0" targetFramework="net45" />
+  <package id="SteamAuth" version="2.0.0" targetFramework="net45" />
   <package id="SteamKit2" version="1.8.1" targetFramework="net45" />
 </packages>

--- a/SteamTrade/SteamTrade.csproj
+++ b/SteamTrade/SteamTrade.csproj
@@ -44,8 +44,8 @@
     <Reference Include="protobuf-net">
       <HintPath>..\packages\protobuf-net.2.0.0.668\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="SteamAuth, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SteamAuth.1.1.0\lib\net45\SteamAuth.dll</HintPath>
+    <Reference Include="SteamAuth, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SteamAuth.2.0.0\lib\net45\SteamAuth.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SteamKit2, Version=1.8.1.0, Culture=neutral, PublicKeyToken=ed3ce47ed5aad940, processorArchitecture=MSIL">

--- a/SteamTrade/packages.config
+++ b/SteamTrade/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="protobuf-net" version="2.0.0.668" targetFramework="net451" />
-  <package id="SteamAuth" version="1.1.0" targetFramework="net45" />
+  <package id="SteamAuth" version="2.0.0" targetFramework="net45" />
   <package id="SteamKit2" version="1.8.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I update the SteamAuth NuGet package to the latest one that Geel9 released 17 days ago. I never got around to updating the packages required within the actual GitHub SteamBot. So here it is, the latest required packages have all been updated to version 2.0.0. Could someone just check and merge this for me if it is all in order?