### PR TITLE
Update to Generic Inventory to prevent casting errors.

### DIFF
--- a/SteamTrade/GenericInventory.cs
+++ b/SteamTrade/GenericInventory.cs
@@ -208,7 +208,7 @@ namespace SteamTrade
                                             classid = long.Parse((string)class_instance.classid),
                                             url = (class_instance.actions != null && class_instance.actions.First["link"] != null ? class_instance.actions.First["link"] : ""),
                                             app_data = tmpAppData,
-                                            market_fee_app_id = class_instance.market_fee_app,
+                                            market_fee_app_id = (class_instance.market_fee_app != null ? class_instance.market_fee_app : 0),
                                         }
                                     );
                                     break;


### PR DESCRIPTION
I was implementing my own changes to the Generic Inventory when I kept running into a casting error. I managed to troubleshoot the issue and found that non-marketable items would return a market_fee_app_id of null which would cause errors when converting it to "long". The best solution for this was to set the market_fee to 0 when the item was not marketable. This issue could be fixed in many other ways such as seeing if the item is actually marketable but this is the fix I came up with. 

