### PR TITLE
Optional 2FA code on first login

### DIFF
--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -166,19 +166,6 @@ namespace SteamBot
             Admins = config.Admins;
             ApiKey = !String.IsNullOrEmpty(config.ApiKey) ? config.ApiKey : apiKey;
             isProccess = process;
-            if (useTwoFactorByDefault)
-            {
-                var mobileAuthCode = GetMobileAuthCode();
-                if (string.IsNullOrEmpty(mobileAuthCode))
-                {
-                    Log.Error("Failed to generate 2FA code. Make sure you have linked the authenticator via SteamBot.");
-                }
-                else
-                {
-                    logOnDetails.TwoFactorCode = mobileAuthCode;
-                    Log.Success("Generated 2FA code.");
-                }
-            }
             try
             {
                 if( config.LogLevel != null )
@@ -206,6 +193,19 @@ namespace SteamBot
 
             logFile = config.LogFile;
             Log = new Log(logFile, DisplayName, consoleLogLevel, fileLogLevel);
+            if (useTwoFactorByDefault)
+            {
+                var mobileAuthCode = GetMobileAuthCode();
+                if (string.IsNullOrEmpty(mobileAuthCode))
+                {
+                    Log.Error("Failed to generate 2FA code. Make sure you have linked the authenticator via SteamBot.");
+                }
+                else
+                {
+                    logOnDetails.TwoFactorCode = mobileAuthCode;
+                    Log.Success("Generated 2FA code.");
+                }
+            }
             createHandler = handlerCreator;
             BotControlClass = config.BotControlClass;
             SteamWeb = new SteamWeb();

--- a/SteamBot/Bot.cs
+++ b/SteamBot/Bot.cs
@@ -147,7 +147,7 @@ namespace SteamBot
         [Obsolete("Refactored to be Log instead of log")]
         public Log log { get { return Log; } }
 
-        public Bot(Configuration.BotInfo config, string apiKey, UserHandlerCreator handlerCreator, bool debug = false, bool process = false)
+        public Bot(Configuration.BotInfo config, string apiKey, UserHandlerCreator handlerCreator, bool debug = false, bool process = false, bool useTwoFactorByDefault = false)
         {
             userHandlers = new Dictionary<SteamID, UserHandler>();
             logOnDetails = new SteamUser.LogOnDetails
@@ -166,6 +166,19 @@ namespace SteamBot
             Admins = config.Admins;
             ApiKey = !String.IsNullOrEmpty(config.ApiKey) ? config.ApiKey : apiKey;
             isProccess = process;
+            if (useTwoFactorByDefault)
+            {
+                var mobileAuthCode = GetMobileAuthCode();
+                if (string.IsNullOrEmpty(mobileAuthCode))
+                {
+                    Log.Error("Failed to generate 2FA code. Make sure you have linked the authenticator via SteamBot.");
+                }
+                else
+                {
+                    logOnDetails.TwoFactorCode = mobileAuthCode;
+                    Log.Success("Generated 2FA code.");
+                }
+            }
             try
             {
                 if( config.LogLevel != null )


### PR DESCRIPTION
This is kinda useful, especially when your bot is well-established, .auth files are there, _bot always fails his first login attempt without this_, if you spam this  (e.g. restart bot or something), steam is going to temp-ban you for incorrect login attempts.

So far it worked fine for me, bot is able to login on his first attempt and I don't know when is it reasonable to login without 2FA when .auth files already exist

Perhaps adding it as an option to the configuration file is even better